### PR TITLE
Script that deletes all cached stan models

### DIFF
--- a/empty_stan_cache.py
+++ b/empty_stan_cache.py
@@ -1,0 +1,11 @@
+import os
+
+if __name__ == '__main__':
+    here = os.path.dirname(os.path.realpath(__file__))
+    here_to_there = 'data/cached_stan_models/'
+    there = os.path.join(here, here_to_there)
+    targets = os.listdir(there)
+
+    for target in targets:
+        if target.endswith(".pkl"):
+            os.remove(os.path.join(dir_name, there))


### PR DESCRIPTION
This can be used from an ipython repl as follows:

```
%run empty_stan_cache.py
```

It will delete all `.pkl` files in the directory `data/cached_stan_models`. Usually this kind of thing isn't needed as the `StanModel_cache` function I copied from the pystan docs is quite clever, but I think it struggles to recognise when a file that another model includes has changed.