### PR TITLE
Bug: fix run_model.py script

### DIFF
--- a/python/run_model.py
+++ b/python/run_model.py
@@ -98,9 +98,8 @@ if __name__ == '__main__':
     stan_utils.run_compiled_cmdstan_model(stan_model_path.replace('.stan', ''),
                                           input_data_path,
                                           output_data_path,
-                                          num_samples=50,
-                                          num_warmup=50,
-                                          extra_config=extra_config)
+                                          method_config="sample num_samples=50 num_warmup=50",
+                                          refresh_config="refresh=1")
     infd = arviz.from_cmdstan([output_data_path],
                               coords={'kinetic_parameter_names': list(kinetic_parameters.index)},
                               dims={'kinetic_parameters': ['kinetic_parameter_names']})


### PR DESCRIPTION
The `run_compiled_cmdstan_model` call was left over from a previous version.