### PR TITLE
Bug: generate different random seed for each chain

### DIFF
--- a/python/run_model.py
+++ b/python/run_model.py
@@ -14,9 +14,9 @@ ABS_TOL = 1e-6
 MAX_STEPS = int(1e9)
 LIKELIHOOD = 1
 MEASUREMENT_SCALE = 0.05
-N_SAMPLES = 20
-N_WARMUP = 20
-N_CHAINS = 2
+N_SAMPLES = 1000
+N_WARMUP = 1000
+N_CHAINS = 4
 
 if __name__ == '__main__':
     here = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Running multiple chains in parallel wasn't working because the random seed would be the same for all the processes, resulting in each markov chain generating an identical set of samples. This change fixes the issue by randomly generating a different random seed for each cmdstan command.

I've also bumped the default number of warmup and sampling iterations up to 1000 and the chains up to 4, as that should be enough to get some proper results and should go fairly quickly on all of our computers.