### PR TITLE
Bug: increase ode time to 5 minutes to ensure steady state

### DIFF
--- a/data/in/yeast_data.toml
+++ b/data/in/yeast_data.toml
@@ -1,6 +1,6 @@
 [experiment_info]
 FLUX_MEASUREMENT_SCALE = 0.1 # flux measurment accuracy
-STEADY_STATE_TIME = 30  # when is it safe to assume steady state?
+STEADY_STATE_TIME = 300  # when is it safe to assume steady state?
 
 [known_reals]
 ENO1 = 0.686371954155832
@@ -12,7 +12,7 @@ TDH1 = 0.350864642801396
 TDH2 = 0.0
 TDH3 = 4.20440474648547
 TPI1 = 0.294357819645508
-influx_fbp = 0.5
+influx_fbp = 0.5  # Arbitrary value, Smallbone says 1.88
 NAD = 1.41142  # From Smallbone
 NADH = 0.1785794942  # From Smallbone
 ATP = 3.95146  # From Smallbone


### PR DESCRIPTION
This change gives nice results with no diagnosis problems, steady state reached and all the observed metabolite concentrations from the Smallbone paper accounted for. 

The only remaining wrinkle is the hardcoded fbp influx - the value that reaches steady state according to the parameter values in the Smallbone paper is 1.88. Unfortunately setting `influx_fbp` to 1.88 (and adjusting `Vout_pep` accordingly) prevents the model from getting to steady state. Instead, the metabolite f16bp just accumulates, leading to weird downstream behaviour, though the model still converges which is nice. On balance and after chatting with Areti we think this is ok - we don't necessarily have to agree with the Smallbone paper about exactly what this flux should be.