### PR TITLE
Doc: Signpost that the uniuni is haldane-compliant

### DIFF
--- a/enzymekat/code_generation.py
+++ b/enzymekat/code_generation.py
@@ -35,7 +35,6 @@ def create_functions_block(ed: EnzymeKatData) -> str:
 
 def create_fluxes_function(ed: EnzymeKatData) -> str:
     mechanism_to_haldane_functions = {
-        'uniuni': [],
         'ordered_unibi': [
             create_Kip_ordered_unibi_line,
             create_Kiq_ordered_unibi_line

--- a/enzymekat/stan_code/big_k_rate_equations.stan
+++ b/enzymekat/stan_code/big_k_rate_equations.stan
@@ -10,6 +10,10 @@
  */
 
 real uniuni(real A, real P, real V1, real V2, real Ka, real Keq){
+  /*
+    NB this way of formulating the mechanism already takes into account the
+    relevant Haldane relationship!
+  */
   real num = V1*V2*(A-P/Keq);
   real denom = Ka*V2 + V2*A + V1*P/Keq;
   return num / denom;


### PR DESCRIPTION
Very small change pointing out that the uniuni mechanism has a haldane constraint built into its rate equation. The idea is to avoid false bug alarms like #100.