### PR TITLE
Install cmdstan from pypi rather than github

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     matplotlib
     jinja2
     toml
-    cmdstanpy@git+ssh://git@github.com/stan-dev/cmdstanpy
+    cmdstanpy
     click
 python_requires = >=3.7
 packages = enzymekat


### PR DESCRIPTION
Cmdstanpy can now be installed from the python package index, so there is no need to get it from github. This should avoid one of the issues that @LarsKeldNielsen had with installation.

I tested by running 

```
(venv) ~/Code/enzymekat cmdstanpy_pypi $ pip install --no-cache-dir -e .
```

locally in a fresh virtual environment, after which `enzymekat sample` worked ok.