### PR TITLE
Fix issue in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include versioneer.py
 include src/maud/_version.py
 recursive-include tests/data *
-include src/maud/stan_code *.stan
+recursive-include src/maud/stan_code *.stan


### PR DESCRIPTION
This is to make sure tox can see all the stan templates it needs to in order to test Maud's code generation functions.

I broke this line in a previous commit but didn't notice until Nick tried running `tox`. I think this happened because the file `src/Maud.egg-info/SOURCES` was cached on my computer.