### PR TITLE
Documentation skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,12 @@ data/in/*
 data/out/*
 !data/out/readme.md
 
-maud/stan_code/autogen/*
-!maud/stan_code/autogen/readme.md
+src/maud/stan_code/autogen/*
+!src/maud/stan_code/autogen/readme.md
+
+docs/_build/*
+docs/_static/*
+docs/_templates/*
 
 *.DS_Store
 *#

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Maud'
+copyright = '2019, Novo Nordisk Foundation Center for Biosustainability, Technical University of Denmark'
+author = 'Novo Nordisk Foundation Center for Biosustainability, Technical University of Denmark'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/implementation/data_model.rst
+++ b/docs/implementation/data_model.rst
@@ -1,0 +1,4 @@
+Maud's data model
+=================
+
+This document explains the thinking behind Maud's data model.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,27 @@
+.. Maud documentation master file, created by
+   sphinx-quickstart on Fri Oct  4 15:14:47 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Maud's documentation!
+================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   usage/installation
+   usage/inputting
+   theory/computation
+   theory/enzyme_kinetics
+   theory/statistics
+   implementation/data_model
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/theory/computation.rst
+++ b/docs/theory/computation.rst
@@ -1,0 +1,7 @@
+Background on relevant computational issues
+===========================================
+
+This document addresses questions about computation, for example:
+
+  - What is Hamiltonian Monte Carlo and why does Maud use it?
+  - Why does Maud find steady states in the way that it does?

--- a/docs/theory/enzyme_kinetics.rst
+++ b/docs/theory/enzyme_kinetics.rst
@@ -1,0 +1,4 @@
+Background on enzyme kinetics
+=============================
+
+This document explains the assumptions about enzyme kinetics that Maud uses.

--- a/docs/theory/statistics.rst
+++ b/docs/theory/statistics.rst
@@ -1,0 +1,9 @@
+Background on relevant statistical issues
+=========================================
+
+This document addresses statistical questions to do with Maud, such as:
+
+ - How does Maud frame the task of learning from multi-omics data as a
+   statistical inference problem?
+
+ - What are some statistical assumptions that Maud makes?

--- a/docs/usage/inputting.rst
+++ b/docs/usage/inputting.rst
@@ -1,0 +1,5 @@
+How to specify input data for Maud
+==================================
+
+This document explains how to specify kinetic models, prior parameter
+distributions and experimental data in a form that Maud can use.

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -1,0 +1,4 @@
+Installation
+============
+
+This document explains how to install Maud.

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ development =
     black
     isort
     tox
+    sphinx
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
First step towards addressing issue #129.

This change populates the `docs` directory with some files and puts in place some sphinx stuff so that we can easily make a nice documentation website and pdf.

I essentially followed the instructions in the [sphinx getting started guide](http://www.sphinx-doc.org/en/master/usage/quickstart.html) - I installed sphinx then ran `spinx-quickstart`, and created a basic file structure.

The result is that you should be able to create html or pdf versions of the documentation by running `make html` or `make latexpdf` from the `docs` directory. I've added the folders that these commands create to the `.gitignore` to keep things tidy.