### PR TITLE
Test: add a unit test for the io module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,8 @@
 """Set up the Maud package."""
 
 
-from setuptools import setup
-
 import versioneer
+from setuptools import setup
 
 
 # All other arguments are defined in `setup.cfg`.

--- a/tests/test_unit/test_io.py
+++ b/tests/test_unit/test_io.py
@@ -1,0 +1,20 @@
+"""Unit tests for io functions."""
+
+import os
+
+import maud.io as io
+
+
+here = os.path.dirname(__file__)
+data_path = os.path.join(here, "../data")
+
+
+def test_load_maud_input_from_toml():
+    """Test that the function load_maud_input_from_toml behaves as expected."""
+    mi = io.load_maud_input_from_toml(os.path.join(data_path, "linear.toml"))
+    assert mi.kinetic_model.reactions["r1"].stoichiometry == {"M1_ex": -1, "M1": 1}
+    assert mi.priors["r1_Keq"].target_id == "Keq"
+    assert (
+        mi.experiments["condition_1"].measurements["metabolite"]["M1"].target_type
+        == "metabolite"
+    )


### PR DESCRIPTION
A small import change also happened after I ran `make qa`.

I wanted to commit a pickled version of the correct `MaudInput` object to compare against but this turned out to be difficult due to a quirk in the toml library. The lowest level dictionaries (for example `mi.kinetic_model.reactions['r1'].stoichiometry` where `mi` is the output of `load_maud_input_from_toml`) have type `toml.decoder.TomlDecoder.get_empty_inline_table.<locals>.DynamicInlineTableDict`, which the pickle module doesn't like.

Until we find a way round this issue this test will hopefully suffice to catch disastrous changes in how the io module works.