### PR TITLE
Bug: update io test for new thermodynamic parameters

### DIFF
--- a/tests/test_unit/test_io.py
+++ b/tests/test_unit/test_io.py
@@ -13,7 +13,7 @@ def test_load_maud_input_from_toml():
     """Test that the function load_maud_input_from_toml behaves as expected."""
     mi = io.load_maud_input_from_toml(os.path.join(data_path, "linear.toml"))
     assert mi.kinetic_model.reactions["r1"].stoichiometry == {"M1_ex": -1, "M1": 1}
-    assert mi.priors["r1_Keq"].target_id == "Keq"
+    assert mi.priors["r1_dg"].target_id == "r1"
     assert (
         mi.experiments["condition_1"].measurements["metabolite"]["M1"].target_type
         == "metabolite"


### PR DESCRIPTION
This test came from before we changed from Keqs to delta gs, so it doesn't work with the latest master. 

The change fixes the error.