### PR TITLE
Bug: fix qa/tox conflict by adding scipy to known_third_parties

### DIFF
--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -22,10 +22,10 @@ from typing import Dict
 import cmdstanpy
 import numpy as np
 import pandas as pd
+from scipy.linalg import null_space as null_space
 
 from maud import code_generation, io, utils
 from maud.data_model import KineticModel, MaudInput
-from scipy.linalg import null_space as null_space
 
 
 RELATIVE_PATHS = {

--- a/tox.ini
+++ b/tox.ini
@@ -110,4 +110,5 @@ known_third_party =
     black
     depinfo
     pytest
+    scipy
     tox


### PR DESCRIPTION
Fixes a bug where isort would behave differently during the command `make qa` compared to during the command `tox`.