### PR TITLE
Add config files for readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,3 +52,6 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# So that readthedocs will look for index.rst rather than contents.rst
+master_doc = 'index'

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,26 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+     - requirements: docs/requirements.txt
+     - method: pip
+       path: .
+       extra_requirements:
+           - development
+     - method: setuptools
+       path: another/package
+  system_packages: true

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -21,4 +21,5 @@ python:
        extra_requirements:
            - development
      - method: setuptools
+       path: src/maud
   system_packages: true

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -16,11 +16,9 @@ formats: all
 python:
   version: 3.7
   install:
-     - requirements: docs/requirements.txt
      - method: pip
        path: .
        extra_requirements:
            - development
      - method: setuptools
-       path: another/package
   system_packages: true

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -20,6 +20,4 @@ python:
        path: .
        extra_requirements:
            - development
-     - method: setuptools
-       path: src/maud
   system_packages: true


### PR DESCRIPTION
I started a [readthedocs](https://maud-metabolic-models.readthedocs.io/en/latest/) site for Maud in order to get our documentation online. This is to address issue #176.

The site is currently reading from this branch - we can change to master once it gets merged.