### PR TITLE
Fix incorrect license, haldane line function, typo and add diagnostic check after sampling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ author_email = tedgro@dtu.dk
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Science/Research
-    License :: OSI Approved :: Apache Software License
+    License :: OSI Approved :: GNU General Public License version 3
     Natural Language :: English
     Operating System :: MacOS :: MacOS X
     Operating System :: Microsoft :: Windows :: Windows 10
@@ -17,7 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering :: Bio-Informatics
-license = Apache Software License Version 2.0
+license = GNU General Public License version 3
 description = Bayesian statistical models of metabolic networks
 long_description = file: README.rst
 keywords =

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,9 @@
 """Set up the Maud package."""
 
 
-import versioneer
 from setuptools import setup
+
+import versioneer
 
 
 # All other arguments are defined in `setup.cfg`.

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -104,4 +104,5 @@ pass
 def sample(data_path, **kwargs):
     """Sample from the model defined by the data at data_path."""
     stanfit = sampling.sample(data_path, **kwargs)
+    stanfit.diagnose()
     print(stanfit.summary())

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -52,7 +52,7 @@ MECHANISM_TEMPLATES = {
         "ordered_unibi(m[{{S0}}],m[{{P0}}],m[{{P1}}],"
         "p[{{enz}}]*p[{{Kcat1}}],p[{{enz}}]*p[{{Kcat2}}],"
         "p[{{Ka}}],p[{{Kp}}],p[{{Kq}}],"
-        "p[{{Kia}}],{{enz_id}}_Kip,{{enz_id}}_Kiq],"
+        "p[{{Kia}}],{{enz_id}}_Kip,{{enz_id}}_Kiq,"
         "p[{{Keq}}])"
     ),
     "ordered_bibi": Template(
@@ -81,17 +81,17 @@ MECHANISM_TEMPLATES = {
 
 HALDANE_PARAMS = {
     "ordered_unibi": {
-        "Kip": ["Keq", "Kia", "Kq", "Kcat1", "Kcat2"],
-        "Kiq": ["Keq", "Ka", "Kp", "Kcat1", "Kcat2"],
+        "Kip": ["delta_g", "Kia", "Kq", "Kcat1", "Kcat2"],
+        "Kiq": ["delta_g", "Ka", "Kp", "Kcat1", "Kcat2"],
     },
     "ordered_bibi": {
-        "Kia": ["Keq", "Kb", "Kp", "Kiq", "Kcat1", "Kcat2"],
-        "Kip": ["Keq", "Ka", "Kq", "Kib", "Kcat1", "Kcat2"],
+        "Kia": ["delta_g", "Kb", "Kp", "Kiq", "Kcat1", "Kcat2"],
+        "Kip": ["delta_g", "Ka", "Kq", "Kib", "Kcat1", "Kcat2"],
     },
-    "pingpong": {"Kp": ["Keq", "Ka", "Kb", "Kq", "Kcat1", "Kcat2"]},
+    "pingpong": {"Kp": ["delta_g", "Ka", "Kb", "Kq", "Kcat1", "Kcat2"]},
     "ordered_terbi": {
-        "Kip": ["Keq", "Kia", "Kib", "Kic", "Kiq"],
-        "Kp": ["Keq", "Kc", "Kia", "Kib", "Kiq", "Kcat1", "Kcat2"],
+        "Kip": ["delta_g", "Kia", "Kib", "Kic", "Kiq"],
+        "Kp": ["delta_g", "Kc", "Kia", "Kib", "Kiq", "Kcat1", "Kcat2"],
     },
 }
 

--- a/tests/test_unit/test_code_generation.py
+++ b/tests/test_unit/test_code_generation.py
@@ -31,7 +31,7 @@ def test_create_haldane_line():
     """Test that the function create_haldane_line behaves as expected."""
     rxn_id = "tr"
     mechanism = "ordered_unibi"
-    param_codes = {"tr_Keq": 1, "tr_Kia": 2, "tr_Kq": 3, "tr_Kcat1": 4, "tr_Kcat2": 5}
+    param_codes = {"tr_delta_g": 1, "tr_Kia": 2, "tr_Kq": 3, "tr_Kcat1": 4, "tr_Kcat2": 5}
     expected_line = "real tr_Kip = get_Kip_ordered_unibi(p[1],p[2],p[3],p[4],p[5]);"
     generated_line = code_generation.create_haldane_line(
         param_codes, "Kip", mechanism, rxn_id, code_generation.HALDANE_PARAMS
@@ -87,7 +87,7 @@ def test_mechanism_templates():
     expected_calls = {
         "uniuni": "uniuni(m[1],m[4],p[1]*p[3],p[1]*p[4],p[5],p[2])",
         "ordered_unibi": "ordered_unibi(m[1],m[4],m[5],p[1]*p[3],p[1]*p[4],p[5],"
-        "p[8],p[9],p[10],e1_Kip,e1_Kiq],p[2])",
+        "p[8],p[9],p[10],e1_Kip,e1_Kiq,p[2])",
         "ordered_bibi": "ordered_bibi(m[1],m[2],m[4],m[5],p[1]*p[3],p[1]*p[4],"
         "p[5],p[6],p[8],p[9],e1_Kia,p[11],e1_Kip,p[13],p[2])",
         "pingpong": "pingpong(m[1],m[2],m[4],m[5],p[1]*p[3],p[1]*p[4],p[5],p[6],"

--- a/tests/test_unit/test_code_generation.py
+++ b/tests/test_unit/test_code_generation.py
@@ -31,7 +31,13 @@ def test_create_haldane_line():
     """Test that the function create_haldane_line behaves as expected."""
     rxn_id = "tr"
     mechanism = "ordered_unibi"
-    param_codes = {"tr_delta_g": 1, "tr_Kia": 2, "tr_Kq": 3, "tr_Kcat1": 4, "tr_Kcat2": 5}
+    param_codes = {
+        "tr_delta_g": 1,
+        "tr_Kia": 2,
+        "tr_Kq": 3,
+        "tr_Kcat1": 4,
+        "tr_Kcat2": 5,
+    }
     expected_line = "real tr_Kip = get_Kip_ordered_unibi(p[1],p[2],p[3],p[4],p[5]);"
     generated_line = code_generation.create_haldane_line(
         param_codes, "Kip", mechanism, rxn_id, code_generation.HALDANE_PARAMS


### PR DESCRIPTION
This pr fixes a few bugs that I ran into while preparing a demo. It also adds a call to the cmdstan `diagnose` function after sampling - this used to happen automatically and should help us to catch problematic models.

First, there is a problem with the Haldane code generation where some `Keq`s should be `delta_g`s.

Second, there is a stray `]` in an ordered unibi template.

Finally, there are some leftover references to the old apache license in `setup.cfg`.

