### PR TITLE
Pos neg allostery

### DIFF
--- a/data/in/linear.toml
+++ b/data/in/linear.toml
@@ -36,6 +36,7 @@ stoichiometry = { M1_ex = -1, M1 = 1}
 id = 'r1'
 name = 'the enzyme that catalyses reaction r1'
 mechanism = 'uniuni'
+allosteric_activators = ['M2']
 
 [[reactions]]
 id = 'r2'
@@ -85,6 +86,8 @@ r1 = [
   { target_id = 'Kcat1', location = 1, scale = 0.6},
   { target_id = 'Kcat2', location = 1, scale = 0.6},
   { target_id = 'Ka', location = 1, scale = 0.6},
+  { target_id = 'dissociation_constant_r', metabolite = 'M2', location= 1, scale = 0.6},
+  { target_id = 'transfer_constant', location= 1, scale = 0.6},
 ]
 r2 = [
   { target_id = 'Kcat1', location = 1, scale = 0.6},

--- a/data/in/linear.toml
+++ b/data/in/linear.toml
@@ -35,7 +35,7 @@ stoichiometry = { M1_ex = -1, M1 = 1}
 [[reactions.enzymes]]
 id = 'r1'
 name = 'the enzyme that catalyses reaction r1'
-mechanism = 'uniuni'
+mechanism = 'modular_rate_law'
 allosteric_activators = ['M2']
 
 [[reactions]]
@@ -45,8 +45,9 @@ stoichiometry = { M1 = -1, M2 = 1 }
 [[reactions.enzymes]]
 id = 'r2'
 name = 'the enzyme that catalyses reaction r2'
-mechanism = 'uniuni'
+mechanism = 'modular_rate_law'
 allosteric_inhibitors = ['M1']
+competitive_inhibitors = ['M2']
 
 [[reactions]]
 id = 'r3'
@@ -55,7 +56,7 @@ stoichiometry = { M2 = -1, M2_ex = 1}
 [[reactions.enzymes]]
 id = 'r3'
 name = 'the enzyme that catalyses reaction r3'
-mechanism = 'uniuni'
+mechanism = 'modular_rate_law'
 
 ###### Experimental data ######
 [[experiments]]
@@ -84,21 +85,22 @@ reaction_measurements = [
 [priors.kinetic_parameters]
 r1 = [
   { target_id = 'Kcat1', location = 1, scale = 0.6},
-  { target_id = 'Kcat2', location = 1, scale = 0.6},
+  { target_id = 'Kp', location = 1, scale = 0.6},
   { target_id = 'Ka', location = 1, scale = 0.6},
   { target_id = 'dissociation_constant_r', metabolite = 'M2', location= 1, scale = 0.6},
   { target_id = 'transfer_constant', location= 1, scale = 0.6},
 ]
 r2 = [
   { target_id = 'Kcat1', location = 1, scale = 0.6},
-  { target_id = 'Kcat2', location = 1, scale = 0.6},
+  { target_id = 'Kp', location = 1, scale = 0.6},
   { target_id = 'Ka', location = 1, scale = 0.6},
   { target_id = 'dissociation_constant_t', metabolite = 'M1', location= 1, scale = 0.6},
   { target_id = 'transfer_constant', location= 1, scale = 0.6},
+  { target_id = 'inhibition_constant', metabolite = 'M2', location= 1, scale = 0.6},
 ]
 r3 = [
   { target_id = 'Kcat1', location = 1, scale = 0.6},
-  { target_id = 'Kcat2', location = 1, scale = 0.6},
+  { target_id = 'Kp', location = 1, scale = 0.6},
   { target_id = 'Ka', location = 1, scale = 0.6},
 ]
 

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -318,8 +318,16 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
             # make modular rate law if necessary
             if enz.mechanism == "modular_rate_law":
                 enz_code = enz_codes_in_theta[enz.id]
-                competitor_ids = [mod.metabolite for mod in enz.modifiers.values() if "competitive_inhibitor" in mod.modifier_type]
-                substrate_block, product_block, competitor_block = get_modular_rate_codes(
+                competitor_ids = [
+                    mod.metabolite
+                    for mod in enz.modifiers.values()
+                    if "competitive_inhibitor" in mod.modifier_type
+                ]
+                (
+                    substrate_block,
+                    product_block,
+                    competitor_block,
+                ) = get_modular_rate_codes(
                     enz_id,
                     competitor_ids,
                     substrate_stoichiometries,

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -376,8 +376,8 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
                     if mod.modifier_type == "allosteric_inhibitor"
                 }
                 allosteric_activators = {
-                    mod_id: mod
-                    for mod_id, mod in enz.modifiers.items()
+                    mod.metabolite: mod
+                    for mod in enz.modifiers.values()
                     if mod.modifier_type == "allosteric_activator"
                 }
                 allosteric_inhibitor_codes = {

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -383,10 +383,10 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
                     mod_id: met_codes[mod_id] for mod_id in allosteric_activators.keys()
                 }
                 regulatory_string = get_regulatory_string(
-                    allosteric_inhibitor_codes, 
+                    allosteric_inhibitor_codes,
                     allosteric_activator_codes,
-                    kp_codes_in_theta, 
-                    enz.id
+                    kp_codes_in_theta,
+                    enz.id,
                 )
                 enzyme_flux_string = catalytic_string + "*" + regulatory_string
             else:
@@ -405,8 +405,8 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
 def get_regulatory_string(
     inhibitor_codes: Dict[str, int],
     activator_codes: Dict[str, int],
-    param_codes: Dict[str, int], 
-    enzyme_name: str
+    param_codes: Dict[str, int],
+    enzyme_name: str,
 ) -> str:
     """Create a call to the Stan function get_regulatory_effect.
 

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -369,8 +369,7 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
                 }
 
             catalytic_string = MECHANISM_TEMPLATES[enz.mechanism].render(mechanism_args)
-            is_allosteric = [1 for mod in enz.modifiers.values() if mod.allosteric]
-            if any(is_allosteric):
+            if any([mod.allosteric for mod in enz.modifiers.values()]):
                 # make free enzyme ratio line
                 free_enzyme_ratio_line = Template(
                     "real free_enzyme_ratio_{{enzyme}} = "
@@ -378,16 +377,14 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
                 ).render(enzyme=enz_id, catalytic_string=catalytic_string)
                 free_enzyme_ratio_lines.append(free_enzyme_ratio_line)
                 # make regulatory effect string
-                allosteric_inhibitors = {
-                    mod.metabolite: mod
-                    for mod in enz.modifiers.values()
-                    if mod.modifier_type == "allosteric_inhibitor"
-                }
-                allosteric_activators = {
-                    mod.metabolite: mod
-                    for mod in enz.modifiers.values()
-                    if mod.modifier_type == "allosteric_activator"
-                }
+                allosteric_inhibitors, allosteric_activators = (
+                    {
+                        mod.metabolite: mod
+                        for mod in enz.modifiers.values()
+                        if mod.modifier_type == modifier_type
+                    }
+                    for modifier_type in ["allosteric_inhibitor", "allosteric_activator"]
+                )
                 allosteric_inhibitor_codes = {
                     mod_id: met_codes[mod_id] for mod_id in allosteric_inhibitors.keys()
                 }

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -383,7 +383,10 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
                         for mod in enz.modifiers.values()
                         if mod.modifier_type == modifier_type
                     }
-                    for modifier_type in ["allosteric_inhibitor", "allosteric_activator"]
+                    for modifier_type in [
+                        "allosteric_inhibitor",
+                        "allosteric_activator",
+                    ]
                 )
                 allosteric_inhibitor_codes = {
                     mod_id: met_codes[mod_id] for mod_id in allosteric_inhibitors.keys()

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -138,6 +138,9 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
                         }
                     )
             if "competitive_inhibitors" in e.keys():
+                if e["mechanism"] != "modular_rate_law":
+                    raise ValueError("competitive inhibitors are currently only supported for the mechanism 'modular_rate_law'")
+
                 for inhibitor_id in e["competitive_inhibitors"]:
                     modifiers.update(
                         {f"{inhibitor_id}_competitive_inhibitors": Modifier(inhibitor_id, "competitive_inhibitor")}

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -89,7 +89,10 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
                     param_id["target_id"]: Parameter(param_id["target_id"], e["id"])
                     for param_id in parsed_toml["priors"]["kinetic_parameters"][e["id"]]
                     if param_id["target_id"]
-                    not in ["dissociation_constant_t", "transfer_constant"]
+                    not in ["dissociation_constant_t",
+                            "dissociation_constant_r",
+                            "inhibition_constant",
+                            "transfer_constant"]
                 }
             else:
                 params = {
@@ -97,69 +100,64 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
                     for param_id in MECHANISM_TO_PARAM_IDS[e["mechanism"]]
                 }
             params["delta_g"] = Parameter("delta_g", e["id"], is_thermodynamic=True)
-            allosteric_inhibitors = defaultdict()
-            allosteric_activators = defaultdict()
-            competitive_inhibitors = defaultdict()
-            allosteric_params = defaultdict()
+            modifiers = defaultdict()
+            modifier_params = defaultdict()
             if any(
                 [
                     x in ["allosteric_inhibitors", "allosteric_activators"]
                     for x in e.keys()
                 ]
             ):
-                allosteric_params = {
+                modifier_params = {
                     "transfer_constant": Parameter("transfer_constant", e["id"])
                 }
             if "allosteric_inhibitors" in e.keys():
                 for inhibitor_id in e["allosteric_inhibitors"]:
-                    allosteric_inhibitors.update(
-                        {inhibitor_id: Modifier(inhibitor_id, "allosteric_inhibitor")}
+                    modifiers.update(
+                        {f"{inhibitor_id}_allosteric_inhibitor": Modifier(inhibitor_id, "allosteric_inhibitor")}
                     )
                     diss_t_const_id = f"dissociation_constant_t_{inhibitor_id}"
-                    allosteric_params.update(
+                    modifier_params.update(
                         {
                             diss_t_const_id: Parameter(
                                 diss_t_const_id, e["id"], inhibitor_id
                             )
                         }
                     )
-                params.update(allosteric_params)
             if "allosteric_activators" in e.keys():
                 for activator_id in e["allosteric_activators"]:
-                    allosteric_activators.update(
-                        {activator_id: Modifier(activator_id, "allosteric_activator")}
+                    modifiers.update(
+                        {f"{activator_id}_allosteric_allosteric_activator": Modifier(activator_id, "allosteric_activator")}
                     )
                     diss_r_const_id = f"dissociation_constant_r_{activator_id}"
-                    allosteric_params.update(
+                    modifier_params.update(
                         {
                             diss_r_const_id: Parameter(
                                 diss_r_const_id, e["id"], activator_id
                             )
                         }
                     )
-                params.update(allosteric_params)
-
             if "competitive_inhibitors" in e.keys():
                 for inhibitor_id in e["competitive_inhibitors"]:
-                    competitive_inhibitors.update(
-                        {inhibitor_id: Modifier(inhibitor_id, "competitive_inhibitor")}
+                    modifiers.update(
+                        {f"{inhibitor_id}_competitive_inhibitors": Modifier(inhibitor_id, "competitive_inhibitor")}
                     )
                     inhibition_constant_id = f"inhibition_constant_{inhibitor_id}"
-                    allosteric_params.update(
+                    modifier_params.update(
                         {
                             inhibition_constant_id: Parameter(
                                 inhibition_constant_id, e["id"], inhibitor_id
                             )
                         }
                     )
-
+            params.update(modifier_params)
             enz = Enzyme(
                 id=e["id"],
                 name=e["name"],
                 reaction_id=r["id"],
                 mechanism=e["mechanism"],
                 parameters=params,
-                modifiers=allosteric_inhibitors,
+                modifiers=modifiers,
             )
             rxn_enzymes.update({enz.id: enz})
         rxn = Reaction(

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -89,10 +89,12 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
                     param_id["target_id"]: Parameter(param_id["target_id"], e["id"])
                     for param_id in parsed_toml["priors"]["kinetic_parameters"][e["id"]]
                     if param_id["target_id"]
-                    not in ["dissociation_constant_t",
-                            "dissociation_constant_r",
-                            "inhibition_constant",
-                            "transfer_constant"]
+                    not in [
+                        "dissociation_constant_t",
+                        "dissociation_constant_r",
+                        "inhibition_constant",
+                        "transfer_constant",
+                    ]
                 }
             else:
                 params = {
@@ -114,7 +116,11 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
             if "allosteric_inhibitors" in e.keys():
                 for inhibitor_id in e["allosteric_inhibitors"]:
                     modifiers.update(
-                        {f"{inhibitor_id}_allosteric_inhibitor": Modifier(inhibitor_id, "allosteric_inhibitor")}
+                        {
+                            f"{inhibitor_id}_allosteric_inhibitor": Modifier(
+                                inhibitor_id, "allosteric_inhibitor"
+                            )
+                        }
                     )
                     diss_t_const_id = f"dissociation_constant_t_{inhibitor_id}"
                     modifier_params.update(
@@ -127,7 +133,11 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
             if "allosteric_activators" in e.keys():
                 for activator_id in e["allosteric_activators"]:
                     modifiers.update(
-                        {f"{activator_id}_allosteric_allosteric_activator": Modifier(activator_id, "allosteric_activator")}
+                        {
+                            f"{activator_id}_allosteric_allosteric_activator": Modifier(
+                                activator_id, "allosteric_activator"
+                            )
+                        }
                     )
                     diss_r_const_id = f"dissociation_constant_r_{activator_id}"
                     modifier_params.update(
@@ -139,11 +149,18 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
                     )
             if "competitive_inhibitors" in e.keys():
                 if e["mechanism"] != "modular_rate_law":
-                    raise ValueError("competitive inhibitors are currently only supported for the mechanism 'modular_rate_law'")
+                    raise ValueError(
+                        """competitive inhibitors are currently
+                        only supported for the mechanism 'modular_rate_law'"""
+                    )
 
                 for inhibitor_id in e["competitive_inhibitors"]:
                     modifiers.update(
-                        {f"{inhibitor_id}_competitive_inhibitors": Modifier(inhibitor_id, "competitive_inhibitor")}
+                        {
+                            f"{inhibitor_id}_competitive_inhibitors": Modifier(
+                                inhibitor_id, "competitive_inhibitor"
+                            )
+                        }
                     )
                     inhibition_constant_id = f"inhibition_constant_{inhibitor_id}"
                     modifier_params.update(

--- a/src/maud/stan_code/allostery.stan
+++ b/src/maud/stan_code/allostery.stan
@@ -77,6 +77,6 @@ real get_free_enzyme_ratio_ordered_terbi(real A, real B, real C, real P, real Q,
     + Ka*V2*B*C*P*Q/(Kip*Kiq);
   return num / denom;
 }
-real get_free_enzyme_ratio_modular_rate_law(real Tr, real Dr){
-  return 1 / (Dr);
+real get_free_enzyme_ratio_modular_rate_law(real Tr, real Dr, real Dr_reg){
+  return 1 / (Dr + Dr_reg);
 }

--- a/src/maud/stan_code/big_k_rate_equations.stan
+++ b/src/maud/stan_code/big_k_rate_equations.stan
@@ -97,8 +97,8 @@ real ordered_terbi(real A, real B, real C, real P, real Q,
     + Ka*V2*B*C*P*Q/(Kip*Kiq);
   return num/denom;
 }
-real modular_rate_law(real Tr, real Dr){
-  return(Tr/(Dr));
+real modular_rate_law(real Tr, real Dr, real Dr_reg){
+  return(Tr/(Dr + Dr_reg));
 }
 real irr_mass_action(real A, real V1){
   return(A*V1);

--- a/src/maud/stan_code/modular_rate_law.stan
+++ b/src/maud/stan_code/modular_rate_law.stan
@@ -14,3 +14,11 @@ real Dr_{{enz_id}} = {%- for su in substrate_list %} (1 + m[{{su[0]}}]/p[{{su[1]
                 + {%- for pr in product_list %} (1 + m[{{pr[0]}}]/p[{{pr[1]}}])^{{pr[2]}} {{"*" if not loop.last}}
                 {%- endfor %}
                 - 1;
+
+{% if competitive_inhibitor_list %}
+real Dr_reg_{{enz_id}} = {%- for ci in competitive_inhibitor_list %} (m[{{ci[0]}}]/p[{{ci[1]}}]) {{"*" if not loop.last}}
+    {%- endfor %};
+
+{% else %}
+real Dr_reg_{{enz_id}} = 0;
+    {%- endif %}

--- a/tests/test_unit/test_code_generation.py
+++ b/tests/test_unit/test_code_generation.py
@@ -89,6 +89,7 @@ def test_mechanism_templates():
         "Kiq": 13,
         "Tr": 1,
         "Dr": 2,
+        "Dr_reg": 0,
     }
     enzyme_id = "e1"
     expected_calls = {
@@ -101,7 +102,7 @@ def test_mechanism_templates():
         "p[8],p[9],p[10],p[11],e1_Kip,p[13],p[2])",
         "ordered_terbi": "ordered_terbi(m[1],m[2],m[3],m[4],m[5],p[1]*p[3],"
         "p[1]*p[4],p[5],p[6],p[7],e1_Kp,p[9],p[10],p[11],p[12],e1_Kip,p[13],p[2])",
-        "modular_rate_law": "modular_rate_law(1,2)",
+        "modular_rate_law": "modular_rate_law(1,2, 0)",
     }
     generated_calls = {
         mechanism: template.render({**codes, **{"enz_id": enzyme_id}})
@@ -115,15 +116,16 @@ def test_mechanism_templates():
 
 def test_get_modular_rate_codes():
     """Check that the function get_modular_rate_codes works as expected."""
-    rxn_id = "r"
+    enz_id = "r"
+    competitor_info = []
     substrate_info = [["m1", -1], ["m2", -1]]
     product_info = [["m3", 1], ["m4", 1]]
     par_codes = {"r_keq": 0.1, "r_Ka": 0.1, "r_Kb": 0.3, "r_Kp": 0.2, "r_Kq": 0.2}
     met_codes = {"m1": 1, "m2": 2, "m3": 3, "m4": 4}
-    expected_output = [[[1, 0.1, -1], [2, 0.3, -1]], [[3, 0.2, 1], [4, 0.2, 1]]]
+    expected_output = [[[1, 0.1, -1], [2, 0.3, -1]], [[3, 0.2, 1], [4, 0.2, 1]], []]
     assert (
         code_generation.get_modular_rate_codes(
-            rxn_id, substrate_info, product_info, par_codes, met_codes
+            enz_id, competitor_info, substrate_info, product_info, par_codes, met_codes
         )
         == expected_output
     )

--- a/tests/test_unit/test_code_generation.py
+++ b/tests/test_unit/test_code_generation.py
@@ -48,6 +48,7 @@ def test_create_haldane_line():
 def test_get_regulatory_string():
     """Test that the function get_regulatory_string behaves as expected."""
     inhibitor_codes = {"m1": 1, "m2": 2}
+    activator_codes = {}
     param_codes = {
         "e1_dissociation_constant_t_m1": 2,
         "e1_dissociation_constant_t_m2": 3,
@@ -55,7 +56,7 @@ def test_get_regulatory_string():
     }
     enzyme_name = "e1"
     generated = code_generation.get_regulatory_string(
-        inhibitor_codes, param_codes, enzyme_name
+        inhibitor_codes, activator_codes, param_codes, enzyme_name
     )
     expected = (
         "get_regulatory_effect("


### PR DESCRIPTION
# Summary

Adding positive allostery and competitive inhibition (for modular rate law only) as a feature to Maud. Positive allostery is integrated into the MWC framework. There is an example in the `data/in/linear.toml` file about how both mechanisms can be used. As a summary, all it requires is an allosteric_activators/competitive_inhibitors field in the reaction.enzymes section, like with the following example:

[[reactions.enzymes]]
id = 'r1'
name = 'the enzyme that catalyses reaction r1'
mechanism = 'uniuni'
allosteric_activators = ['M2']
competitive_inhibitors = ['M1']

and in the parameters section it requires 1 transfer constant for each reaction that has allostery, regardless of how many allosteric inhibitors/activators and must be specified with the following format:

  { target_id = 'dissociation_constant_r', metabolite = 'M2', location= 1, scale = 0.6},
  { target_id = 'inhibition_constant', metabolite = 'M1', location= 1, scale = 0.6},
  { target_id = 'transfer_constant', location= 1, scale = 0.6}


## Commits
* Feat: adding positive allosteric regulation
* Chore: updating tests and making qa
* Feat: adding example of pos. allostery in linear pathway
* Feat: adding support for competitive_inhibition
* Bug: fixing indexing
* Merge branch 'competitive_inhibition' into pos_neg_allostery
* Bug: fixing indexing and added check
* Model: updating mechanisms for linear model
* Chore: make qa and fixing tests
* Style: addressing Teddy's comments
* Chore: fixing black/flake8 error