### PR TITLE
Put output data in the same file that maud sample was run from

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *__pycache__*
 data/cached_stan_models/*.pkl
 */.ipynb_checkpoints/*
+*.csv
+*.txt
+*.json
 
 data/stan_records/*
 data/in/*
@@ -11,9 +14,6 @@ data/in/*
 !data/in/yeast_measurements.csv
 !data/in/inits_yeast.Rdump
 !data/in/model_input_yeast.Rdump
-
-data/out/*
-!data/out/readme.md
 
 src/maud/stan_code/autogen/*
 !src/maud/stan_code/autogen/readme.md

--- a/data/out/readme.md
+++ b/data/out/readme.md
@@ -1,1 +1,0 @@
-Store output data here

--- a/data/stan_records/readme.md
+++ b/data/stan_records/readme.md
@@ -1,1 +1,0 @@
-Store data for stan model here

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -96,6 +96,9 @@ pass
     default=SAMPLING_DEFAULTS["time_step"],
     help="How far ahead the ode solver simulates",
 )
+@click.option(
+    "--output_dir", default="./", help="Where to save Maud's output",
+)
 @click.argument(
     "data_path",
     type=click.Path(exists=True, dir_okay=False),


### PR DESCRIPTION
This change removes the folders `data/out` and `data/stan_records` and sends the output of `maud sample` to the current directory, or a directory of the user's choice if they use the `--output_dir` option.

The reason for making this change is to make it possible to use Maud without changing directory to wherever it is installed. After this change it should be possible to start using Maud by just doing

```
pip install https://github.com/biosustain/Maud/archive/master.zip
maud sample path/to/data.toml
```