### PR TITLE
Model all measurements in the same way

### DIFF
--- a/data/in/linear.toml
+++ b/data/in/linear.toml
@@ -70,9 +70,16 @@ metadata = "A bat got in the bioreactor."
 metabolite_measurements = [
   {target_id='M1_c', value=0.8, uncertainty=0.1},
   {target_id='M2_c', value=1.5, uncertainty=0.1},
+  {target_id='M1_e', value=2, uncertainty=0.05},
+  {target_id='M2_e', value=1, uncertainty=0.05},
 ]
 reaction_measurements = [
   {target_id='r3', value=0.29, uncertainty=0.1}
+]
+enzyme_measurements = [
+  {target_id='r1', value=1, uncertainty=0.05},
+  {target_id='r2', value=1, uncertainty=0.05},
+  {target_id='r3', value=1, uncertainty=0.05},
 ]
 
 [[experiments]]
@@ -81,9 +88,16 @@ metadata = "I may have mixed up some/all of the numbers."
 metabolite_measurements = [
   {target_id='M1_c', value=0.7, uncertainty=0.1},
   {target_id='M2_c', value=1.4, uncertainty=0.1},
+  {target_id='M1_e', value=2, uncertainty=0.05},
+  {target_id='M2_e', value=1, uncertainty=0.05},
 ]
 reaction_measurements = [
   {target_id='r3', value=0.21, uncertainty=0.1}
+]
+enzyme_measurements = [
+  {target_id='r1', value=1.5, uncertainty=0.05},
+  {target_id='r2', value=1.5, uncertainty=0.05},
+  {target_id='r3', value=1.5, uncertainty=0.05},
 ]
 
 ###### Priors ######
@@ -113,26 +127,4 @@ r3 = [
 formation_energies = [
   { target_id = 'M1', location = -1, scale = 0.05},
   { target_id = 'M2', location = -2, scale = 0.05},
-]
-
-[priors.unbalanced_metabolites]
-condition_1 = [
-  {target_id='M1_e', location=2, scale=0.05},
-  {target_id='M2_e', location=1, scale=0.05},
-]
-condition_2 = [
-  {target_id='M1_e', location=2, scale=0.05},
-  {target_id='M2_e', location=1, scale=0.05},
-]
-
-[priors.enzymes]
-condition_1 = [
-  {target_id='r1', location=1, scale=0.05},
-  {target_id='r2', location=1, scale=0.05},
-  {target_id='r3', location=1, scale=0.05},
-]
-condition_2 = [
-  {target_id='r1', location=1.5, scale=0.05},
-  {target_id='r2', location=1.5, scale=0.05},
-  {target_id='r3', location=1.5, scale=0.05},
 ]

--- a/data/in/yeast.toml
+++ b/data/in/yeast.toml
@@ -176,10 +176,28 @@ metabolite_measurements = [
   { target_id = 'f16p_c', value = 2.78, uncertainty = 0.05},
   { target_id = 'g3p_c', value = 0.067, uncertainty = 0.05},
   { target_id = '13dpg_c', value = 0.0016, uncertainty = 0.05},
+  { target_id = 'glc__D_e', value = 74, uncertainty = 0.05 },
+  { target_id = 'atp_c', value = 3.95, uncertainty = 0.05 },
+  { target_id = 'adp_c', value = 1.73, uncertainty = 0.05 },
+  { target_id = 'nad_c', value = 1.41, uncertainty = 0.05 },
+  { target_id = 'nadh_c', value = 0.178, uncertainty = 0.05 },
+  { target_id = 'dhap_c', value = 1.58, uncertainty = 0.05},
+  { target_id = '3pg_c', value = 0.52, uncertainty = 0.05 },
+  { target_id = 'pi_c', value = 2, uncertainty = 0.05 },
 ]
 reaction_measurements = [
   { target_id = 'GLCt1', value = 1.88, uncertainty = 0.05},
   { target_id = 'TPI', value = 1.83, uncertainty = 0.05},
+]
+enzyme_measurements = [
+  {target_id='GLCt1', value=1, uncertainty=0.05},
+  {target_id='HEX1', value=0.062, uncertainty=0.1},
+  {target_id='PGI', value=0.138, uncertainty=0.05},
+  {target_id='PFK', value=0.085, uncertainty=0.05},
+  {target_id='FBA', value=1.34, uncertainty=0.05},
+  {target_id='TPI', value=0.295, uncertainty=0.05},
+  {target_id='GAPD', value=4.2, uncertainty=0.05},
+  {target_id='PGK', value=0.258, uncertainty=0.05},
 ]
 
 ###### Priors ######
@@ -255,24 +273,8 @@ formation_energies = [
 
 [priors.unbalanced_metabolites]
 condition_1 = [
-  { target_id = 'glc__D_e', location = 74, scale = 0.05 },
-  { target_id = 'atp_c', location = 3.95, scale = 0.05 },
-  { target_id = 'adp_c', location = 1.73, scale = 0.05 },
-  { target_id = 'nad_c', location = 1.41, scale = 0.05 },
-  { target_id = 'nadh_c', location = 0.178, scale = 0.05 },
-  { target_id = 'dhap_c', location = 1.58, scale = 0.05},
-  { target_id = '3pg_c', location = 0.52, scale = 0.05 },
-  { target_id = 'pi_c', location = 2, scale = 0.05 },
 ]
 [priors.enzymes]
 condition_1 = [
   # Glycolysis
-  {target_id='GLCt1', location=1, scale=0.05},
-  {target_id='HEX1', location=0.062, scale=0.1},
-  {target_id='PGI', location=0.138, scale=0.05},
-  {target_id='PFK', location=0.085, scale=0.05},
-  {target_id='FBA', location=1.34, scale=0.05},
-  {target_id='TPI', location=0.295, scale=0.05},
-  {target_id='GAPD', location=4.2, scale=0.05},
-  {target_id='PGK', location=0.258, scale=0.05},
 ]

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -219,7 +219,7 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
     experiments = {}
     for e in parsed_toml["experiments"]:
         experiment = Experiment(id=e["id"])
-        for target_type in ["metabolite", "reaction"]:
+        for target_type in ["metabolite", "reaction", "enzyme"]:
             type_measurements = {}
             for m in e[target_type + "_measurements"]:
                 measurement = Measurement(
@@ -244,17 +244,17 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
             scale=formation_energy_prior["scale"],
             target_type="thermodynamic_parameter",
         )
-    for exp_id, umps in parsed_toml["priors"]["unbalanced_metabolites"].items():
-        for ump in umps:
-            prior_id = f"{exp_id}_{ump['target_id']}"
-            priors[prior_id] = Prior(
-                id=prior_id,
-                target_id=ump["target_id"],
-                location=ump["location"],
-                scale=ump["scale"],
-                target_type="unbalanced_metabolite",
-                experiment_id=exp_id,
-            )
+    # for exp_id, umps in parsed_toml["priors"]["unbalanced_metabolites"].items():
+        # for ump in umps:
+            # prior_id = f"{exp_id}_{ump['target_id']}"
+            # priors[prior_id] = Prior(
+                # id=prior_id,
+                # target_id=ump["target_id"],
+                # location=ump["location"],
+                # scale=ump["scale"],
+                # target_type="unbalanced_metabolite",
+                # experiment_id=exp_id,
+            # )
     for enz_id, kpps in parsed_toml["priors"]["kinetic_parameters"].items():
         for kpp in kpps:
             prior_id = f"{enz_id}_{kpp['target_id']}"
@@ -267,17 +267,17 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
                 scale=kpp["scale"],
                 target_type="kinetic_parameter",
             )
-    for exp_id, eps in parsed_toml["priors"]["enzymes"].items():
-        for ep in eps:
-            prior_id = f"{exp_id}_{ep['target_id']}"
-            priors[prior_id] = Prior(
-                id=prior_id,
-                target_id=ep["target_id"],
-                location=ep["location"],
-                scale=ep["scale"],
-                target_type="enzyme",
-                experiment_id=exp_id,
-            )
+    # for exp_id, eps in parsed_toml["priors"]["enzymes"].items():
+        # for ep in eps:
+            # prior_id = f"{exp_id}_{ep['target_id']}"
+            # priors[prior_id] = Prior(
+                # id=prior_id,
+                # target_id=ep["target_id"],
+                # location=ep["location"],
+                # scale=ep["scale"],
+                # target_type="enzyme",
+                # experiment_id=exp_id,
+            # )
 
     mi = MaudInput(kinetic_model=kinetic_model, priors=priors, experiments=experiments)
     validation.validate_maud_input(mi)

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -244,17 +244,6 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
             scale=formation_energy_prior["scale"],
             target_type="thermodynamic_parameter",
         )
-    # for exp_id, umps in parsed_toml["priors"]["unbalanced_metabolites"].items():
-        # for ump in umps:
-            # prior_id = f"{exp_id}_{ump['target_id']}"
-            # priors[prior_id] = Prior(
-                # id=prior_id,
-                # target_id=ump["target_id"],
-                # location=ump["location"],
-                # scale=ump["scale"],
-                # target_type="unbalanced_metabolite",
-                # experiment_id=exp_id,
-            # )
     for enz_id, kpps in parsed_toml["priors"]["kinetic_parameters"].items():
         for kpp in kpps:
             prior_id = f"{enz_id}_{kpp['target_id']}"
@@ -267,17 +256,6 @@ def load_maud_input_from_toml(filepath: str, id: str = "mi") -> MaudInput:
                 scale=kpp["scale"],
                 target_type="kinetic_parameter",
             )
-    # for exp_id, eps in parsed_toml["priors"]["enzymes"].items():
-        # for ep in eps:
-            # prior_id = f"{exp_id}_{ep['target_id']}"
-            # priors[prior_id] = Prior(
-                # id=prior_id,
-                # target_id=ep["target_id"],
-                # location=ep["location"],
-                # scale=ep["scale"],
-                # target_type="enzyme",
-                # experiment_id=exp_id,
-            # )
 
     mi = MaudInput(kinetic_model=kinetic_model, priors=priors, experiments=experiments)
     validation.validate_maud_input(mi)

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -91,7 +91,9 @@ def sample(
 
     mi = io.load_maud_input_from_toml(data_path)
 
-    input_data, init_cond = get_input_data(mi, f_tol, rel_tol, max_steps, likelihood)
+    input_data = get_input_data(mi, f_tol, rel_tol, max_steps, likelihood)
+    init_cond = get_initial_conditions(input_data)
+
     cmdstanpy.utils.jsondump(input_filepath, input_data)
 
     stan_program_filepath = os.path.join(
@@ -176,19 +178,13 @@ def get_input_data(
     formation_energy_priors = formation_energy_priors.set_index("target_id").reindex(
         metabolite_codes_no_compartments
     )
-    prior_loc_unb, prior_loc_enzyme, prior_scale_unb, prior_scale_enzyme = (
-        prior_df.loc[lambda df: df["target_type"] == target_type]
-        .set_index(["target_id", "experiment_id"])[col]
-        .unstack()
-        .loc[list(codes.keys()), list(experiment_codes.keys())]
-        for col in ["location", "scale"]
-        for target_type, codes in [
-            ("unbalanced_metabolite", unb_metabolite_codes),
-            ("enzyme", enzyme_codes),
-        ]
-    )
-
-    metabolite_measurements, reaction_measurements = (
+    unbalanced_param_shape = len(unbalanced_metabolites), len(mi.experiments)
+    enzyme_param_shape = len(enzymes), len(mi.experiments)
+    prior_loc_unbalanced = np.full(unbalanced_param_shape, 0.1)
+    prior_scale_unbalanced = np.full(unbalanced_param_shape, 1)
+    prior_loc_enzyme = np.full(enzyme_param_shape, 0.1)
+    prior_scale_enzyme = np.full(enzyme_param_shape, 1)
+    metabolite_measurements, reaction_measurements, enzyme_measurements = (
         pd.DataFrame(
             [
                 [exp.id, meas.target_id, meas.value, meas.uncertainty]
@@ -197,57 +193,74 @@ def get_input_data(
             ],
             columns=["experiment_id", "target_id", "value", "uncertainty"],
         )
-        for measurement_type in ["metabolite", "reaction"]
+        for measurement_type in ["metabolite", "reaction", "enzyme"]
     )
-    return [
-        {
-            "N_balanced": len(balanced_metabolites),
-            "N_unbalanced": len(unbalanced_metabolites),
-            "N_kinetic_parameters": len(kinetic_parameter_priors),
-            "N_reaction": len(reactions),
-            "N_enzyme": len(enzymes),
-            "N_experiment": len(mi.experiments),
-            "N_flux_measurement": len(reaction_measurements),
-            "N_conc_measurement": len(metabolite_measurements),
-            "N_metabolite": len(formation_energy_priors),
-            "stoichiometric_matrix": full_stoic.T.values,
-            "compartment_metabolite_index": compartment_metabolite_index,
-            "experiment_yconc": (
-                metabolite_measurements["experiment_id"].map(experiment_codes).values
-            ),
-            "metabolite_yconc": (
-                metabolite_measurements["target_id"].map(metabolite_codes).values
-            ),
-            "yconc": metabolite_measurements["value"].values,
-            "sigma_conc": metabolite_measurements["uncertainty"].values,
-            "experiment_yflux": (
-                reaction_measurements["experiment_id"].map(experiment_codes).values
-            ),
-            "reaction_yflux": (
-                reaction_measurements["target_id"].map(reaction_codes).values
-            ),
-            "yflux": reaction_measurements["value"].values,
-            "sigma_flux": reaction_measurements["uncertainty"].values,
-            "prior_loc_formation_energy": formation_energy_priors["location"].values,
-            "prior_scale_formation_energy": formation_energy_priors["scale"].values,
-            "prior_loc_kinetic_parameters": kinetic_parameter_priors["location"].values,
-            "prior_scale_kinetic_parameters": kinetic_parameter_priors["scale"].values,
-            "prior_loc_unbalanced": prior_loc_unb.values,
-            "prior_scale_unbalanced": prior_scale_unb.values,
-            "prior_loc_enzyme": prior_loc_enzyme.values,
-            "prior_scale_enzyme": prior_scale_enzyme.values,
-            "as_guess": [0.01 for m in range(len(balanced_metabolites))],
-            "rtol": rel_tol,
-            "ftol": f_tol,
-            "steps": max_steps,
-            "LIKELIHOOD": likelihood,
-        },
-        {
-            "kinetic_parameters": kinetic_parameter_priors["location"].values,
-            "unbalanced": np.transpose(prior_loc_unb.values),
-            "enzyme_concentration": np.transpose(prior_loc_enzyme.values),
-            "formation_energy": np.transpose(
-                formation_energy_priors["location"].values
-            ),
-        },
-    ]
+    return {
+        "N_balanced": len(balanced_metabolites),
+        "N_unbalanced": len(unbalanced_metabolites),
+        "N_kinetic_parameters": len(kinetic_parameter_priors),
+        "N_reaction": len(reactions),
+        "N_enzyme": len(enzymes),
+        "N_experiment": len(mi.experiments),
+        "N_flux_measurement": len(reaction_measurements),
+        "N_enzyme_measurement": len(enzyme_measurements),
+        "N_conc_measurement": len(metabolite_measurements),
+        "N_metabolite": len(formation_energy_priors),
+        "stoichiometric_matrix": full_stoic.T.values,
+        "compartment_metabolite_index": compartment_metabolite_index,
+        "experiment_yconc": (
+            metabolite_measurements["experiment_id"].map(experiment_codes).values
+        ),
+        "metabolite_yconc": (
+            metabolite_measurements["target_id"].map(metabolite_codes).values
+        ),
+        "yconc": metabolite_measurements["value"].values,
+        "sigma_conc": metabolite_measurements["uncertainty"].values,
+        "experiment_yflux": (
+            reaction_measurements["experiment_id"].map(experiment_codes).values
+        ),
+        "reaction_yflux": (
+            reaction_measurements["target_id"].map(reaction_codes).values
+        ),
+        "yflux": reaction_measurements["value"].values,
+        "sigma_flux": reaction_measurements["uncertainty"].values,
+        "experiment_yenz": (
+            enzyme_measurements['experiment_id'].map(experiment_codes).values
+        ),
+        "enzyme_yenz": (
+            enzyme_measurements['target_id'].map(enzyme_codes).values
+        ),
+        "yenz": enzyme_measurements["value"].values,
+        "sigma_enz": enzyme_measurements["uncertainty"].values,
+        "prior_loc_formation_energy": formation_energy_priors["location"].values,
+        "prior_scale_formation_energy": formation_energy_priors["scale"].values,
+        "prior_loc_kinetic_parameters": kinetic_parameter_priors["location"].values,
+        "prior_scale_kinetic_parameters": kinetic_parameter_priors["scale"].values,
+        "prior_loc_unbalanced": prior_loc_unbalanced,
+        "prior_scale_unbalanced": prior_scale_unbalanced,
+        "prior_loc_enzyme": prior_loc_enzyme,
+        "prior_scale_enzyme": prior_scale_enzyme,
+        "as_guess": [0.01 for m in range(len(balanced_metabolites))],
+        "rtol": rel_tol,
+        "ftol": f_tol,
+        "steps": max_steps,
+        "LIKELIHOOD": likelihood,
+    }
+
+
+def get_initial_conditions(input_data):
+    enz_shape = input_data["N_experiment"], input_data["N_enzyme"],
+    unb_shape = input_data["N_experiment"], input_data["N_unbalanced"]
+    enz_init = np.full(enz_shape, 0.1)
+    unb_init = np.full(unb_shape, 0.01)
+    for i, (enz_ix, exp_ix) in enumerate(zip(
+            input_data["enzyme_yenz"] - 1,
+            input_data["experiment_yenz"] - 1
+    )):
+        enz_init[exp_ix, enz_ix] = input_data["yenz"][i]
+    return {
+        "kinetic_parameters": input_data["prior_loc_kinetic_parameters"],
+        "unbalanced": unb_init,
+        "enzyme_concentration": enz_init,
+        "formation_energy": input_data["prior_loc_formation_energy"]
+    }

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -225,11 +225,9 @@ def get_input_data(
         "yflux": reaction_measurements["value"].values,
         "sigma_flux": reaction_measurements["uncertainty"].values,
         "experiment_yenz": (
-            enzyme_measurements['experiment_id'].map(experiment_codes).values
+            enzyme_measurements["experiment_id"].map(experiment_codes).values
         ),
-        "enzyme_yenz": (
-            enzyme_measurements['target_id'].map(enzyme_codes).values
-        ),
+        "enzyme_yenz": (enzyme_measurements["target_id"].map(enzyme_codes).values),
         "yenz": enzyme_measurements["value"].values,
         "sigma_enz": enzyme_measurements["uncertainty"].values,
         "prior_loc_formation_energy": formation_energy_priors["location"].values,
@@ -249,18 +247,20 @@ def get_input_data(
 
 
 def get_initial_conditions(input_data):
-    enz_shape = input_data["N_experiment"], input_data["N_enzyme"],
+    enz_shape = (
+        input_data["N_experiment"],
+        input_data["N_enzyme"],
+    )
     unb_shape = input_data["N_experiment"], input_data["N_unbalanced"]
     enz_init = np.full(enz_shape, 0.1)
     unb_init = np.full(unb_shape, 0.01)
-    for i, (enz_ix, exp_ix) in enumerate(zip(
-            input_data["enzyme_yenz"] - 1,
-            input_data["experiment_yenz"] - 1
-    )):
+    for i, (enz_ix, exp_ix) in enumerate(
+        zip(input_data["enzyme_yenz"] - 1, input_data["experiment_yenz"] - 1)
+    ):
         enz_init[exp_ix, enz_ix] = input_data["yenz"][i]
     return {
         "kinetic_parameters": input_data["prior_loc_kinetic_parameters"],
         "unbalanced": unb_init,
         "enzyme_concentration": enz_init,
-        "formation_energy": input_data["prior_loc_formation_energy"]
+        "formation_energy": input_data["prior_loc_formation_energy"],
     }

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -162,9 +162,6 @@ def get_input_data(
     compartment_metabolite_index = [
         metabolite_codes_no_compartments[m.id] for m in metabolites.values()
     ]
-    unb_metabolite_codes = {
-        k: v for k, v in metabolite_codes.items() if not metabolites[k].balanced
-    }
     enzymes = {k: v for r in reactions.values() for k, v in r.enzymes.items()}
     balanced_metabolites = {k: v for k, v in metabolites.items() if v.balanced}
     unbalanced_metabolites = {k: v for k, v in metabolites.items() if not v.balanced}
@@ -247,6 +244,7 @@ def get_input_data(
 
 
 def get_initial_conditions(input_data):
+    """Specify parameters' initial conditions."""
     enz_shape = (
         input_data["N_experiment"],
         input_data["N_enzyme"],

--- a/src/maud/validation.py
+++ b/src/maud/validation.py
@@ -77,32 +77,32 @@ def validate_maud_input(mi: data_model.MaudInput):
                 f"Metabolite {km_met} is in the kinetic model but has no formation"
                 " energy prior."
             )
-    for exp_id, met_id in prior_unb_mets:
-        if met_id not in km_unb_mets:
-            raise ValueError(
-                f"unbalanced metabolite {met_id} has a prior in experiment {exp_id} but"
-                " is not in the kinetic model."
-            )
-    for met_id in km_unb_mets:
-        for exp_id in mi.experiments.keys():
-            if (exp_id, met_id) not in prior_unb_mets:
-                raise ValueError(
-                    f"unbalanced metabolite {met_id} is in the kinetic model but has no"
-                    " prior in experiment {exp_id}."
-                )
-    for exp_id, enz_id in prior_enzs:
-        if enz_id not in km_enzs:
-            raise ValueError(
-                f"enzyme {enz_id} in experiment {exp_id} has a prior but is not in the"
-                " kinetic model."
-            )
-    for enz_id in km_enzs:
-        for exp_id in mi.experiments.keys():
-            if exp_id + "_" + enz_id not in map("_".join, prior_enzs):
-                raise ValueError(
-                    f"enzyme {enz_id} is in the kinetic model but has no prior in"
-                    " experiment {exp_id}."
-                )
+    # for exp_id, met_id in prior_unb_mets:
+        # if met_id not in km_unb_mets:
+            # raise ValueError(
+                # f"unbalanced metabolite {met_id} has a prior in experiment {exp_id} but"
+                # " is not in the kinetic model."
+            # )
+    # for met_id in km_unb_mets:
+        # for exp_id in mi.experiments.keys():
+            # if (exp_id, met_id) not in prior_unb_mets:
+                # raise ValueError(
+                    # f"unbalanced metabolite {met_id} is in the kinetic model but has no"
+                    # " prior in experiment {exp_id}."
+                # )
+    # for exp_id, enz_id in prior_enzs:
+        # if enz_id not in km_enzs:
+            # raise ValueError(
+                # f"enzyme {enz_id} in experiment {exp_id} has a prior but is not in the"
+                # " kinetic model."
+            # )
+    # for enz_id in km_enzs:
+        # for exp_id in mi.experiments.keys():
+            # if exp_id + "_" + enz_id not in map("_".join, prior_enzs):
+                # raise ValueError(
+                    # f"enzyme {enz_id} is in the kinetic model but has no prior in"
+                    # " experiment {exp_id}."
+                # )
     for exp in mi.experiments.values():
         for meas in exp.measurements["metabolite"].values():
             if meas.target_id not in km_unb_mets + km_balanced_mets:

--- a/src/maud/validation.py
+++ b/src/maud/validation.py
@@ -34,7 +34,6 @@ def validate_maud_input(mi: data_model.MaudInput):
     ]
     km_mets_no_compartments = list(set([met.id for met in km.metabolites.values()]))
     km_rxns = [rxn.id for rxn in km.reactions.values()]
-    km_enzs = [enz.id for rxn in km.reactions.values() for enz in rxn.enzymes.values()]
     km_pars = [
         p
         for rxn in km.reactions.values()

--- a/src/maud/validation.py
+++ b/src/maud/validation.py
@@ -77,32 +77,6 @@ def validate_maud_input(mi: data_model.MaudInput):
                 f"Metabolite {km_met} is in the kinetic model but has no formation"
                 " energy prior."
             )
-    # for exp_id, met_id in prior_unb_mets:
-        # if met_id not in km_unb_mets:
-            # raise ValueError(
-                # f"unbalanced metabolite {met_id} has a prior in experiment {exp_id} but"
-                # " is not in the kinetic model."
-            # )
-    # for met_id in km_unb_mets:
-        # for exp_id in mi.experiments.keys():
-            # if (exp_id, met_id) not in prior_unb_mets:
-                # raise ValueError(
-                    # f"unbalanced metabolite {met_id} is in the kinetic model but has no"
-                    # " prior in experiment {exp_id}."
-                # )
-    # for exp_id, enz_id in prior_enzs:
-        # if enz_id not in km_enzs:
-            # raise ValueError(
-                # f"enzyme {enz_id} in experiment {exp_id} has a prior but is not in the"
-                # " kinetic model."
-            # )
-    # for enz_id in km_enzs:
-        # for exp_id in mi.experiments.keys():
-            # if exp_id + "_" + enz_id not in map("_".join, prior_enzs):
-                # raise ValueError(
-                    # f"enzyme {enz_id} is in the kinetic model but has no prior in"
-                    # " experiment {exp_id}."
-                # )
     for exp in mi.experiments.values():
         for meas in exp.measurements["metabolite"].values():
             if meas.target_id not in km_unb_mets + km_balanced_mets:

--- a/tests/data/linear.stan
+++ b/tests/data/linear.stan
@@ -93,6 +93,7 @@ data {
   int<lower=1> N_enzyme;
   int<lower=1> N_experiment;
   int<lower=1> N_flux_measurement;
+  int<lower=1> N_enzyme_measurement;
   int<lower=1> N_conc_measurement;
   int<lower=1> N_metabolite;  // NB metabolites in multiple compartments only count once here
   // measurements
@@ -104,6 +105,10 @@ data {
   int<lower=1,upper=N_reaction> reaction_yflux[N_flux_measurement];
   vector[N_flux_measurement] yflux;
   vector<lower=0>[N_flux_measurement] sigma_flux;
+  int<lower=1,upper=N_experiment> experiment_yenz[N_enzyme_measurement];
+  int<lower=1,upper=N_enzyme> enzyme_yenz[N_enzyme_measurement];
+  vector[N_enzyme_measurement] yenz;
+  vector<lower=0>[N_enzyme_measurement] sigma_enz;
   // hardcoded priors
   vector[N_metabolite] prior_loc_formation_energy;
   vector<lower=0>[N_metabolite] prior_scale_formation_energy;
@@ -161,6 +166,9 @@ model {
     for (c in 1:N_conc_measurement){
       target += lognormal_lpdf(yconc[c] | log(conc[experiment_yconc[c], metabolite_yconc[c]]), sigma_conc[c]);
     }
+    for (ec in 1:N_enzyme_measurement){
+      target += lognormal_lpdf(yenz[ec] | log(enzyme_concentration[experiment_yenz[ec], enzyme_yenz[ec]]), sigma_enz[ec]);
+    }
     for (f in 1:N_flux_measurement){
       target += normal_lpdf(yflux[f] | flux[experiment_yflux[f], reaction_yflux[f]], sigma_flux[f]);
     }
@@ -168,9 +176,13 @@ model {
 }
 generated quantities {
   vector[N_conc_measurement] yconc_sim;
+  vector[N_enzyme_measurement] yenz_sim;
   vector[N_flux_measurement] yflux_sim;
   for (c in 1:N_conc_measurement){
     yconc_sim[c] = lognormal_rng(log(conc[experiment_yconc[c], metabolite_yconc[c]]), sigma_conc[c]);
+  }
+  for (ec in 1:N_enzyme_measurement){
+    yenz_sim[ec] = lognormal_rng(log(enzyme_concentration[experiment_yenz[ec], enzyme_yenz[ec]]), sigma_enz[ec]);
   }
   for (f in 1:N_flux_measurement){
     yflux_sim[f] = normal_rng(flux[experiment_yflux[f], reaction_yflux[f]], sigma_flux[f]);

--- a/tests/data/linear.toml
+++ b/tests/data/linear.toml
@@ -70,9 +70,16 @@ metadata = "A bat got in the bioreactor."
 metabolite_measurements = [
   {target_id='M1_c', value=0.8, uncertainty=0.1},
   {target_id='M2_c', value=1.5, uncertainty=0.1},
+  {target_id='M1_e', value=2, uncertainty=0.05},
+  {target_id='M2_e', value=1, uncertainty=0.05},
 ]
 reaction_measurements = [
   {target_id='r3', value=0.29, uncertainty=0.1}
+]
+enzyme_measurements = [
+  {target_id='r1', value=1, uncertainty=0.05},
+  {target_id='r2', value=1, uncertainty=0.05},
+  {target_id='r3', value=1, uncertainty=0.05},
 ]
 
 [[experiments]]
@@ -81,9 +88,16 @@ metadata = "I may have mixed up some/all of the numbers."
 metabolite_measurements = [
   {target_id='M1_c', value=0.7, uncertainty=0.1},
   {target_id='M2_c', value=1.4, uncertainty=0.1},
+  {target_id='M1_e', value=2, uncertainty=0.05},
+  {target_id='M2_e', value=1, uncertainty=0.05},
 ]
 reaction_measurements = [
   {target_id='r3', value=0.21, uncertainty=0.1}
+]
+enzyme_measurements = [
+  {target_id='r1', value=1.5, uncertainty=0.05},
+  {target_id='r2', value=1.5, uncertainty=0.05},
+  {target_id='r3', value=1.5, uncertainty=0.05},
 ]
 
 ###### Priors ######
@@ -113,26 +127,4 @@ r3 = [
 formation_energies = [
   { target_id = 'M1', location = -1, scale = 0.05},
   { target_id = 'M2', location = -2, scale = 0.05},
-]
-
-[priors.unbalanced_metabolites]
-condition_1 = [
-  {target_id='M1_e', location=2, scale=0.05},
-  {target_id='M2_e', location=1, scale=0.05},
-]
-condition_2 = [
-  {target_id='M1_e', location=2, scale=0.05},
-  {target_id='M2_e', location=1, scale=0.05},
-]
-
-[priors.enzymes]
-condition_1 = [
-  {target_id='r1', location=1, scale=0.05},
-  {target_id='r2', location=1, scale=0.05},
-  {target_id='r3', location=1, scale=0.05},
-]
-condition_2 = [
-  {target_id='r1', location=1.5, scale=0.05},
-  {target_id='r2', location=1.5, scale=0.05},
-  {target_id='r3', location=1.5, scale=0.05},
 ]

--- a/tests/test_unit/test_sampling.py
+++ b/tests/test_unit/test_sampling.py
@@ -21,18 +21,23 @@ def test_get_input_data():
         "N_enzyme": 3,
         "N_experiment": 2,
         "N_flux_measurement": 2,
-        "N_conc_measurement": 4,
+        "N_enzyme_measurement": 6,
+        "N_conc_measurement": 8,
         "N_metabolite": 2,
         "stoichiometric_matrix": [[-1, 0, 0], [0, 0, 1], [1, -1, 0], [0, 1, -1]],
         "compartment_metabolite_index": [1, 2, 1, 2],
-        "experiment_yconc": [1, 1, 2, 2],
-        "metabolite_yconc": [3, 4, 3, 4],
-        "yconc": [0.8, 1.5, 0.7, 1.4],
-        "sigma_conc": [0.1, 0.1, 0.1, 0.1],
+        "experiment_yconc": [1, 1, 1, 1, 2, 2, 2, 2],
+        "metabolite_yconc": [3, 4, 1, 2, 3, 4, 1, 2],
+        "yconc": [0.8, 1.5, 2.0, 1.0, 0.7, 1.4, 2.0, 1.0],
+        "sigma_conc": [0.1, 0.1, 0.05, 0.05, 0.1, 0.1, 0.05, 0.05],
         "experiment_yflux": [1, 2],
         "reaction_yflux": [3, 3],
         "yflux": [0.29, 0.21],
         "sigma_flux": [0.1, 0.1],
+        "experiment_yenz": [1, 1, 1, 2, 2, 2],
+        "enzyme_yenz": [1, 2, 3, 1, 2, 3],
+        "yenz": [1.0, 1.0, 1.0, 1.5, 1.5, 1.5],
+        "sigma_enz": [0.05, 0.05, 0.05, 0.05, 0.05, 0.05],
         "prior_loc_formation_energy": [-1.0, -2.0],
         "prior_scale_formation_energy": [0.05, 0.05],
         "prior_loc_kinetic_parameters": [
@@ -67,10 +72,10 @@ def test_get_input_data():
             0.6,
             0.6,
         ],
-        "prior_loc_unbalanced": [[2.0, 2.0], [1.0, 1.0]],
-        "prior_scale_unbalanced": [[0.05, 0.05], [0.05, 0.05]],
-        "prior_loc_enzyme": [[1.0, 1.5], [1.0, 1.5], [1.0, 1.5]],
-        "prior_scale_enzyme": [[0.05, 0.05], [0.05, 0.05], [0.05, 0.05]],
+        "prior_loc_unbalanced": [[0.1, 0.1], [0.1, 0.1]],
+        "prior_scale_unbalanced": [[1, 1], [1, 1]],
+        "prior_loc_enzyme": [[0.1, 0.1], [0.1, 0.1], [0.1, 0.1]],
+        "prior_scale_enzyme": [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]],
         "as_guess": [0.01, 0.01],
         "rtol": 1e-09,
         "ftol": 1e-06,
@@ -79,7 +84,7 @@ def test_get_input_data():
     }
     toml_input_path = os.path.join(data_path, "linear.toml")
     mi = io.load_maud_input_from_toml(toml_input_path)
-    actual, _ = sampling.get_input_data(mi, 1e-06, 1e-09, int(1e9), 1)
+    actual = sampling.get_input_data(mi, 1e-06, 1e-09, int(1e9), 1)
     assert actual.keys() == expected.keys()
     for k in actual.keys():
         assert_equal(actual[k], expected[k])


### PR DESCRIPTION
This pull request changes the way that Maud handles unbalanced metabolite and enzyme concentration measurements, making them use the same method we use for flux and balanced metabolite concentration measurements.

At present Maud treats flux and balanced metabolite measurements using standard measurement models: the measured values are treated as noisy draws from distributions centred on a latent true value. Unbalanced metabolite and enzyme concentration measurements, on the other hand, are treated as directly specifying prior distributions for these unknowns. There are a few problems with this setup:

- There's no principled reason to use two different setups and it's a bit confusing for different kinds of measurement to be treated differently when the measurement process itself is essentially the same.
- Often measurements won't be available for all unbalanced metabolites or enzymes. We can deal with this by setting non-measurement-based priors in these cases, but a) these priors have different meanings from the ones based on measurements and b) it's a lot of work to manually enter all those priors.
- Sometimes we might have significant non-experimental information about a measured quantity. In order to express all the available information in these cases we need to be able to specify both a prior and a measurement model.

The new approach treats all measurements the same, i.e. as draws from distributions centred on the true parameter value. 

I also made some minor changes to how Maud sets initial parameter values. I made a new function specially for this (previously it was handled by `get_input_data`) and added a little bit of logic so that initial enzyme concentrations are set to measured values where these are available.
