### PR TITLE
Refactor: explicitly distinguish metabolites and metabolites-in-compartments

### DIFF
--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -26,12 +26,7 @@ from typing import Dict, List
 from jinja2 import Environment, PackageLoader, Template
 
 from maud.data_model import KineticModel, MaudInput
-from maud.utils import (
-    codify,
-    get_enzyme_codes,
-    get_kinetic_parameter_codes,
-    get_metabolite_codes,
-)
+from maud.utils import codify, get_enzyme_codes, get_kinetic_parameter_codes
 
 
 TEMPLATE_FILES = [

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -109,9 +109,7 @@ def create_stan_program(mi: MaudInput, model_type: str, time_step=0.05) -> str:
     mic_codes = codify(kinetic_model.mics.keys())
     par_codes = get_kinetic_parameter_codes(kinetic_model)
     balanced_codes = [
-        mic_codes[mic_id]
-        for mic_id, mic in kinetic_model.mics.items()
-        if mic.balanced
+        mic_codes[mic_id] for mic_id, mic in kinetic_model.mics.items() if mic.balanced
     ]
     unbalanced_codes = [
         mic_codes[mic_id]

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -106,17 +106,17 @@ def create_stan_program(mi: MaudInput, model_type: str, time_step=0.05) -> str:
     """
     templates = get_templates()
     kinetic_model = mi.kinetic_model
-    met_codes = get_metabolite_codes(kinetic_model)
+    mic_codes = codify(kinetic_model.mics.keys())
     par_codes = get_kinetic_parameter_codes(kinetic_model)
     balanced_codes = [
-        met_codes[met_id]
-        for met_id, met in kinetic_model.metabolites.items()
-        if met.balanced
+        mic_codes[mic_id]
+        for mic_id, mic in kinetic_model.mics.items()
+        if mic.balanced
     ]
     unbalanced_codes = [
-        met_codes[met_id]
-        for met_id, met in kinetic_model.metabolites.items()
-        if not met.balanced
+        mic_codes[mic_id]
+        for mic_id, mic in kinetic_model.mics.items()
+        if not mic.balanced
     ]
     keq_position = [par_codes[par_id] for par_id in par_codes.keys() if "Keq" in par_id]
     fluxes_function = create_fluxes_function(
@@ -166,14 +166,14 @@ def create_ode_function(kinetic_model: KineticModel, template: Template) -> str:
     rxns = kinetic_model.reactions
     rxn_id_to_stan = codify(rxns.keys())
     metabolite_lines = []
-    for met_id, met in kinetic_model.metabolites.items():
-        if not met.balanced:
+    for mic_id, mic in kinetic_model.mics.items():
+        if not mic.balanced:
             line = "0"
         else:
             line = ""
             for rxn_id, rxn in rxns.items():
-                if met_id in rxn.stoichiometry.keys():
-                    stoich = rxn.stoichiometry[met_id]
+                if mic_id in rxn.stoichiometry.keys():
+                    stoich = rxn.stoichiometry[mic_id]
                     prefix = "+" if stoich > 0 and line != "" else ""
                     rxn_stan = rxn_id_to_stan[rxn_id]
                     line += prefix + str(stoich) + "*fluxes[{}]".format(rxn_stan)
@@ -196,11 +196,11 @@ def create_steady_state_function(
     compare with the initial state
     """
 
-    mets = kinetic_model.metabolites
-    met_codes = dict(zip(mets.keys(), range(1, len(mets) + 1)))
-    balanced_codes = [met_codes[met_id] for met_id, met in mets.items() if met.balanced]
+    mics = kinetic_model.mics
+    mic_codes = codify(mics.keys())
+    balanced_codes = [mic_codes[mic_id] for mic_id, mic in mics.items() if mic.balanced]
     unbalanced_codes = [
-        met_codes[met_id] for met_id, met in mets.items() if not met.balanced
+        mic_codes[mic_id] for mic_id, mic in mics.items() if not mic.balanced
     ]
     return template.render(
         N_balanced=len(balanced_codes),
@@ -262,9 +262,9 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
     :param template: A jinja template
     """
     modular_template = get_templates()["modular_rate_law"]
-    unbalanced = [m for m in kinetic_model.metabolites.values() if not m.balanced]
+    unbalanced = [m for m in kinetic_model.mics.values() if not m.balanced]
     kp_codes = get_kinetic_parameter_codes(kinetic_model)
-    met_codes = get_metabolite_codes(kinetic_model)
+    mic_codes = codify(kinetic_model.mics.keys())
     enz_codes = keq_codes = get_enzyme_codes(kinetic_model)
 
     # Add increments to codes so they can be referred to in context of stacked
@@ -283,13 +283,13 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
     free_enzyme_ratio_lines = []
     flux_lines = []
     for _, rxn in kinetic_model.reactions.items():
-        substrate_ids = [met_id for met_id, s in rxn.stoichiometry.items() if s < 0]
+        substrate_ids = [mic_id for mic_id, s in rxn.stoichiometry.items() if s < 0]
         substrate_codes = {
-            "S" + str(i): met_codes[met_id] for i, met_id in enumerate(substrate_ids)
+            "S" + str(i): mic_codes[mic_id] for i, mic_id in enumerate(substrate_ids)
         }
-        product_ids = [met_id for met_id, s in rxn.stoichiometry.items() if s > 0]
+        product_ids = [mic_id for mic_id, s in rxn.stoichiometry.items() if s > 0]
         product_codes = {
-            "P" + str(i): met_codes[met_id] for i, met_id in enumerate(product_ids)
+            "P" + str(i): mic_codes[mic_id] for i, mic_id in enumerate(product_ids)
         }
         enzyme_flux_strings = []
         for enz_id, enz in rxn.enzymes.items():
@@ -317,7 +317,7 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
             if enz.mechanism == "modular_rate_law":
                 enz_code = enz_codes_in_theta[enz.id]
                 competitor_ids = [
-                    mod.metabolite
+                    mod.mic
                     for mod in enz.modifiers.values()
                     if "competitive_inhibitor" in mod.modifier_type
                 ]
@@ -331,7 +331,7 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
                     substrate_stoichiometries,
                     product_stoichiometries,
                     kp_codes_in_theta,
-                    met_codes,
+                    mic_codes,
                 )
                 modular_line = modular_template.render(
                     enz_id=enz_id,
@@ -377,7 +377,7 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
                 # make regulatory effect string
                 allosteric_inhibitors, allosteric_activators = (
                     {
-                        mod.metabolite: mod
+                        mod.mic: mod
                         for mod in enz.modifiers.values()
                         if mod.modifier_type == modifier_type
                     }
@@ -387,10 +387,10 @@ def create_fluxes_function(kinetic_model: KineticModel, template: Template) -> s
                     ]
                 )
                 allosteric_inhibitor_codes = {
-                    mod_id: met_codes[mod_id] for mod_id in allosteric_inhibitors.keys()
+                    mod_id: mic_codes[mod_id] for mod_id in allosteric_inhibitors.keys()
                 }
                 allosteric_activator_codes = {
-                    mod_id: met_codes[mod_id] for mod_id in allosteric_activators.keys()
+                    mod_id: mic_codes[mod_id] for mod_id in allosteric_activators.keys()
                 }
                 regulatory_string = get_regulatory_string(
                     allosteric_inhibitor_codes,
@@ -484,21 +484,21 @@ def get_modular_rate_codes(
     substrate_info: List[List],
     product_info: List[List],
     par_codes: Dict[str, int],
-    met_codes: Dict[str, int],
+    mic_codes: Dict[str, int],
 ) -> List[List[int]]:
     """Get codes that can be put into the modular rate law jinja template.
 
     The function returns a list containing lists substrate_input and
     product_input. Each of these is a list containing lists with the form
-    [met_code, param_code, stoic] for each substrate and product.
+    [mic_code, param_code, stoic] for each substrate and product.
 
     :param rxn_id: id of the reaction
-    :param substrate_info: list containing lists with the form [met_id, stoic]
-    where met_id is a string and stoic is a float
-    :param product_info: list containing lists with the form [met_id, stoic]
-    where met_id is a string and stoic is a float
+    :param substrate_info: list containing lists with the form [mic_id, stoic]
+    where mic_id is a string and stoic is a float
+    :param product_info: list containing lists with the form [mic_id, stoic]
+    where mic_id is a string and stoic is a float
     :param par_codes: dictionary mapping parameter ids to integers
-    :param met_codes: dictionary mapping metabolite ids to integers
+    :param mic_codes: dictionary mapping metabolite-in-compartment ids to integers
     """
 
     substrate_keys = ["a", "b", "c", "d"]
@@ -509,16 +509,16 @@ def get_modular_rate_codes(
     for info, keys in zip(
         [substrate_info, product_info], [substrate_keys, product_keys]
     ):
-        for i, (met_id, stoic) in enumerate(info):
+        for i, (mic_id, stoic) in enumerate(info):
             param_id = enz_id + "_K" + keys[i]
             param_code = par_codes[param_id]
-            met_code = met_codes[met_id]
+            mic_code = mic_codes[mic_id]
             if stoic < 0:
-                substrate_input.append([met_code, param_code, stoic])
+                substrate_input.append([mic_code, param_code, stoic])
             elif stoic > 0:
-                product_input.append([met_code, param_code, stoic])
+                product_input.append([mic_code, param_code, stoic])
     for comp in competitor_ids:
-        competitor_code = met_codes[comp]
+        competitor_code = mic_codes[comp]
         param_id = enz_id + "_inhibition_constant_" + comp
         competitor_parameter = par_codes[param_id]
         competitor_input.append([competitor_code, competitor_parameter])

--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -76,14 +76,14 @@ class MetaboliteInCompartment:
 class Modifier:
     """Constructor for modifier objects.
 
-    :param met: the metabolite that is the modifier
+    :param mic: the metabolite-in-compartment that is the modifier
     :param allosteric: whether or not the modifier is allosteric
     :param modifier_type: what is the modifier type:
     'allosteric_activator', 'allosteric_inhibitor', 'competitive inhibitor'
     """
 
-    def __init__(self, metabolite: Metabolite, modifier_type: str = None):
-        self.metabolite = metabolite
+    def __init__(self, mic: MetaboliteInCompartment, modifier_type: str = None):
+        self.mic = mic
         self.allosteric = modifier_type in [
             "allosteric_inhibitor",
             "allosteric_activator",

--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -42,9 +42,7 @@ class Metabolite:
     """
 
     def __init__(
-        self,
-        id: str,
-        name: str = None,
+        self, id: str, name: str = None,
     ):
         self.id = id
         self.name = name if name is not None else id

--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -39,22 +39,38 @@ class Metabolite:
 
     :param id: metabolite id, use a BiGG id if possible.
     :param name: metabolite name.
-    :param balanced: Doe this metabolite have an unchanging concentration at
-    steady state?
-    :param compartment: compartment for the metabolite.
     """
 
     def __init__(
         self,
         id: str,
         name: str = None,
-        balanced: bool = None,
-        compartment: Compartment = None,
     ):
         self.id = id
         self.name = name if name is not None else id
+
+
+class MetaboliteInCompartment:
+    """A metabolite, in a compartment, or mic for short.
+
+    :param id: this mic's id, usually <metabolite_id>_<compartment_id>.
+    :param metabolite_id: id of this mic's metabolite
+    :param compartment_id: id of this mic's compartment
+    :param balanced: Does this mic have stable concentration at steady state?
+
+    """
+
+    def __init__(
+        self,
+        id: str,
+        metabolite_id: str = None,
+        compartment_id: str = None,
+        balanced: bool = None,
+    ):
+        self.id = id
+        self.metabolite_id = metabolite_id
+        self.compartment_id = compartment_id
         self.balanced = balanced
-        self.compartment = compartment
 
 
 class Modifier:
@@ -165,6 +181,7 @@ class KineticModel:
     :param metabolites: dictionary mapping strings to metabolite objects
     :param reactions: dictionary mapping strings to reaction objects
     :param compartments: dictionary mapping strings to compartment objects
+    :param mic: dictionary mapping strings to MetaboliteInCompartment objects
     """
 
     def __init__(
@@ -173,11 +190,13 @@ class KineticModel:
         metabolites: Dict[str, Metabolite],
         reactions: Dict[str, Reaction],
         compartments: Dict[str, Compartment],
+        mics: Dict[str, MetaboliteInCompartment],
     ):
         self.model_id = model_id
         self.metabolites = metabolites
         self.reactions = reactions
         self.compartments = compartments
+        self.mics = mics
 
 
 class Measurement:

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -34,6 +34,7 @@ from maud.data_model import (
     MaudInput,
     Measurement,
     Metabolite,
+    MetaboliteInCompartment,
     Modifier,
     Parameter,
     Prior,
@@ -75,13 +76,15 @@ def load_kinetic_model_from_toml(
         for c in parsed_toml["compartments"]
     }
     metabolites = {
-        m["id"]
-        + "_"
-        + m["compartment"]: Metabolite(
-            id=m["id"],
-            name=m["name"],
+        m["id"]: Metabolite(id=m["id"], name=m["name"])
+        for m in parsed_toml["metabolites"]
+    }
+    mics = {
+        f"{m['id']}_{m['compartment']}": MetaboliteInCompartment(
+            id=f"{m['id']}_{m['compartment']}",
+            metabolite_id=m["id"],
+            compartment_id=m["compartment"],
             balanced=m["balanced"],
-            compartment=m["compartment"],
         )
         for m in parsed_toml["metabolites"]
     }
@@ -90,6 +93,7 @@ def load_kinetic_model_from_toml(
         model_id=model_id,
         metabolites=metabolites,
         compartments=compartments,
+        mics=mics,
         reactions=reactions,
     )
 

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -163,17 +163,15 @@ def get_input_data(
     enzymes = {k: v for r in reactions.values() for k, v in r.enzymes.items()}
     balanced_mics = {k: v for k, v in mics.items() if v.balanced}
     unbalanced_mics = {k: v for k, v in mics.items() if not v.balanced}
-    full_stoic = get_full_stoichiometry(
-        mi.kinetic_model, enzyme_codes, mic_codes
-    )
+    full_stoic = get_full_stoichiometry(mi.kinetic_model, enzyme_codes, mic_codes)
     kinetic_parameter_priors, formation_energy_priors = (
         prior_df.loc[lambda df: df["target_type"] == target_type].copy()
         for target_type in ["kinetic_parameter", "thermodynamic_parameter"]
     )
-    formation_energy_priors['metabolite_code'] = (
-        formation_energy_priors['target_id'].map(metabolite_codes)
-    )
-    formation_energy_priors = formation_energy_priors.sort_values('metabolite_code')
+    formation_energy_priors["metabolite_code"] = formation_energy_priors[
+        "target_id"
+    ].map(metabolite_codes)
+    formation_energy_priors = formation_energy_priors.sort_values("metabolite_code")
     unbalanced_param_shape = len(unbalanced_mics), len(mi.experiments)
     enzyme_param_shape = len(enzymes), len(mi.experiments)
     prior_loc_unbalanced = np.full(unbalanced_param_shape, 0.1)

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -150,38 +150,37 @@ def get_input_data(
         ],
     )
     metabolites = mi.kinetic_model.metabolites
+    mics = mi.kinetic_model.mics
     reactions = mi.kinetic_model.reactions
     reaction_codes = utils.codify(reactions.keys())
     enzyme_codes = code_generation.get_enzyme_codes(mi.kinetic_model)
     experiment_codes = utils.codify(mi.experiments.keys())
-    metabolite_codes = code_generation.get_metabolite_codes(mi.kinetic_model)
-    metabolite_ids_no_compartments = np.unique(
-        [m.id for m in mi.kinetic_model.metabolites.values()]
-    )
-    metabolite_codes_no_compartments = utils.codify(metabolite_ids_no_compartments)
-    compartment_metabolite_index = [
-        metabolite_codes_no_compartments[m.id] for m in metabolites.values()
-    ]
+    metabolite_codes = utils.codify(metabolites.keys())
+    mic_codes = utils.codify(mics.keys())
+    mic_to_met = {
+        mic_codes[mic.id]: metabolite_codes[mic.metabolite_id] for mic in mics.values()
+    }
     enzymes = {k: v for r in reactions.values() for k, v in r.enzymes.items()}
-    balanced_metabolites = {k: v for k, v in metabolites.items() if v.balanced}
-    unbalanced_metabolites = {k: v for k, v in metabolites.items() if not v.balanced}
+    balanced_mics = {k: v for k, v in mics.items() if v.balanced}
+    unbalanced_mics = {k: v for k, v in mics.items() if not v.balanced}
     full_stoic = get_full_stoichiometry(
-        mi.kinetic_model, enzyme_codes, metabolite_codes
+        mi.kinetic_model, enzyme_codes, mic_codes
     )
     kinetic_parameter_priors, formation_energy_priors = (
-        prior_df.loc[lambda df: df["target_type"] == target_type]
+        prior_df.loc[lambda df: df["target_type"] == target_type].copy()
         for target_type in ["kinetic_parameter", "thermodynamic_parameter"]
     )
-    formation_energy_priors = formation_energy_priors.set_index("target_id").reindex(
-        metabolite_codes_no_compartments
+    formation_energy_priors['metabolite_code'] = (
+        formation_energy_priors['target_id'].map(metabolite_codes)
     )
-    unbalanced_param_shape = len(unbalanced_metabolites), len(mi.experiments)
+    formation_energy_priors = formation_energy_priors.sort_values('metabolite_code')
+    unbalanced_param_shape = len(unbalanced_mics), len(mi.experiments)
     enzyme_param_shape = len(enzymes), len(mi.experiments)
     prior_loc_unbalanced = np.full(unbalanced_param_shape, 0.1)
     prior_scale_unbalanced = np.full(unbalanced_param_shape, 1)
     prior_loc_enzyme = np.full(enzyme_param_shape, 0.1)
     prior_scale_enzyme = np.full(enzyme_param_shape, 1)
-    metabolite_measurements, reaction_measurements, enzyme_measurements = (
+    mic_measurements, reaction_measurements, enzyme_measurements = (
         pd.DataFrame(
             [
                 [exp.id, meas.target_id, meas.value, meas.uncertainty]
@@ -193,26 +192,24 @@ def get_input_data(
         for measurement_type in ["metabolite", "reaction", "enzyme"]
     )
     return {
-        "N_balanced": len(balanced_metabolites),
-        "N_unbalanced": len(unbalanced_metabolites),
+        "N_balanced": len(balanced_mics),
+        "N_unbalanced": len(unbalanced_mics),
         "N_kinetic_parameters": len(kinetic_parameter_priors),
         "N_reaction": len(reactions),
         "N_enzyme": len(enzymes),
         "N_experiment": len(mi.experiments),
         "N_flux_measurement": len(reaction_measurements),
         "N_enzyme_measurement": len(enzyme_measurements),
-        "N_conc_measurement": len(metabolite_measurements),
-        "N_metabolite": len(formation_energy_priors),
+        "N_conc_measurement": len(mic_measurements),
+        "N_metabolite": len(metabolites),
         "stoichiometric_matrix": full_stoic.T.values,
-        "compartment_metabolite_index": compartment_metabolite_index,
+        "compartment_metabolite_index": list(mic_to_met.values()),
         "experiment_yconc": (
-            metabolite_measurements["experiment_id"].map(experiment_codes).values
+            mic_measurements["experiment_id"].map(experiment_codes).values
         ),
-        "metabolite_yconc": (
-            metabolite_measurements["target_id"].map(metabolite_codes).values
-        ),
-        "yconc": metabolite_measurements["value"].values,
-        "sigma_conc": metabolite_measurements["uncertainty"].values,
+        "metabolite_yconc": mic_measurements["target_id"].map(mic_codes).values,
+        "yconc": mic_measurements["value"].values,
+        "sigma_conc": mic_measurements["uncertainty"].values,
         "experiment_yflux": (
             reaction_measurements["experiment_id"].map(experiment_codes).values
         ),
@@ -235,7 +232,7 @@ def get_input_data(
         "prior_scale_unbalanced": prior_scale_unbalanced,
         "prior_loc_enzyme": prior_loc_enzyme,
         "prior_scale_enzyme": prior_scale_enzyme,
-        "as_guess": [0.01 for m in range(len(balanced_metabolites))],
+        "as_guess": [0.01 for m in range(len(balanced_mics))],
         "rtol": rel_tol,
         "ftol": f_tol,
         "steps": max_steps,

--- a/src/maud/validation.py
+++ b/src/maud/validation.py
@@ -22,16 +22,8 @@ from maud import data_model
 def validate_maud_input(mi: data_model.MaudInput):
     """Check that priors, experiments and kinetic model are consistent."""
     km = mi.kinetic_model
-    km_unb_mets = [
-        mic.id
-        for mic in km.mics.values()
-        if not mic.balanced
-    ]
-    km_balanced_mets = [
-        mic.id
-        for mic in km.mics.values()
-        if mic.balanced
-    ]
+    km_unb_mets = [mic.id for mic in km.mics.values() if not mic.balanced]
+    km_balanced_mets = [mic.id for mic in km.mics.values() if mic.balanced]
     km_mets_no_compartments = list(set([met.id for met in km.metabolites.values()]))
     km_rxns = [rxn.id for rxn in km.reactions.values()]
     km_pars = [

--- a/src/maud/validation.py
+++ b/src/maud/validation.py
@@ -23,14 +23,14 @@ def validate_maud_input(mi: data_model.MaudInput):
     """Check that priors, experiments and kinetic model are consistent."""
     km = mi.kinetic_model
     km_unb_mets = [
-        met.id + "_" + met.compartment
-        for met in km.metabolites.values()
-        if not met.balanced
+        mic.id
+        for mic in km.mics.values()
+        if not mic.balanced
     ]
     km_balanced_mets = [
-        met.id + "_" + met.compartment
-        for met in km.metabolites.values()
-        if met.balanced
+        mic.id
+        for mic in km.mics.values()
+        if mic.balanced
     ]
     km_mets_no_compartments = list(set([met.id for met in km.metabolites.values()]))
     km_rxns = [rxn.id for rxn in km.reactions.values()]


### PR DESCRIPTION
Maud's data universe needs to include metabolites-in-compartments in order to handle e.g. internal vs external glucose. It also has to include non-compartmentalised metabolites in order to properly handle transport reactions' thermodynamics - unless we tell the model that internal and external glucose are the same, we risk allowing them to have different formation energies.

The current implementation handles both metabolites and metabolites-in-compartments, but does so implicitly. The `Metabolite` class really represents metabolites-in-compartments, and there is a bit of logic determining which of these are really the same substance. This is a bit confusing and the code that sets Stan codes for these things gets hard to follow. 

This pull request changes Maud's data model so that it has separate `Metabolite` and `MetaboliteInCompartment` classes. This allows the `sampling` module to more straightforwardly set formation energy priors and codes for metabolites and metabolites-in-compartments (I've started calling these `mic`s).

This change doesn't affect how data is put into Maud at all: in future we might want to tidy things up there but I thought I'd leave it alone for now to avoid breaking any of @denisshepelin's work.