### PR TITLE
Update cmdstanpy and fix compilation bug

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     matplotlib
     jinja2
     toml
-    cmdstanpy
+    cmdstanpy >=0.8.0
     click
     depinfo
 python_requires = >=3.7

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -97,7 +97,7 @@ pass
     help="How far ahead the ode solver simulates",
 )
 @click.option(
-    "--output_dir", default="./", help="Where to save Maud's output",
+    "--output_dir", default=".", help="Where to save Maud's output",
 )
 @click.argument(
     "data_path",

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -108,10 +108,12 @@ def sample(
     if need_to_overwrite:
         with open(stan_program_filepath, "w") as f:
             f.write(stan_code)
-        for p in [exe_file_path, exe_file_path + '.o', exe_file_path + '.hpp']:
+        for p in [exe_file_path, exe_file_path + ".o", exe_file_path + ".hpp"]:
             if os.path.exists(p):
                 os.remove(p)
-    model = cmdstanpy.CmdStanModel(stan_file=stan_program_filepath, include_paths=[paths["stan_includes"]])
+    model = cmdstanpy.CmdStanModel(
+        stan_file=stan_program_filepath, include_paths=[paths["stan_includes"]]
+    )
     return model.sample(
         data=input_filepath,
         chains=n_chains,


### PR DESCRIPTION
This change fixes an annoying bug was causing Maud to throw an error the first time it ran after the stan source code was changed. 

It turned out that a `.hpp` file that should have been deleted wasn't, causing cmdstanpy to think there was no need to create a new one and resulting in the error.

This change removes the executable, `.hpp` and `.o` file for a model (if they exist) in advance whenever there is a need to recompile. This fixed the bug for me.

I've also added a change to the `setup.cfg` file that should ensure that the latest version of cmdstanpy is installed, and fixed a couple of things that the new version broke (the file saving mechanism changed a bit).
