### PR TITLE
More reliable indexing

### DIFF
--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -285,8 +285,8 @@ class MaudInput:
     :param kinetic_system: a KineticSystem object
     :param priors: a dictionary mapping prior ids to Prior objects
     :param stan codes: a dictionary with keys 'metabolite', 'reaction', 'mic',
-    'experiment' and 'kinetic_parameter', whose values are dictionaries mapping ids
-    of the relevant objects to integer codes
+    'experiment', 'balanced_mic', 'unbalanced_mic' and 'kinetic_parameter', whose
+    values are dictionaries mapping ids of the relevant objects to integer codes
     :param experiments: a dictionary mapping experiment ids to Experiment objects
     """
 

--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -284,6 +284,9 @@ class MaudInput:
 
     :param kinetic_system: a KineticSystem object
     :param priors: a dictionary mapping prior ids to Prior objects
+    :param stan codes: a dictionary with keys 'metabolite', 'reaction', 'mic',
+    'experiment' and 'kinetic_parameter', whose values are dictionaries mapping ids
+    of the relevant objects to integer codes
     :param experiments: a dictionary mapping experiment ids to Experiment objects
     """
 
@@ -291,10 +294,12 @@ class MaudInput:
         self,
         kinetic_model: KineticModel,
         priors: Dict[str, Prior],
+        stan_codes: Dict[str, Dict[str, int]],
         experiments: Dict[str, Experiment] = None,
     ):
         if experiments is None:
             experiments = defaultdict()
         self.kinetic_model = kinetic_model
         self.priors = priors
+        self.stan_codes = stan_codes
         self.experiments = experiments

--- a/src/maud/stan_code/inference_model_lower_blocks.stan
+++ b/src/maud/stan_code/inference_model_lower_blocks.stan
@@ -77,7 +77,6 @@ model {
   }
   if (LIKELIHOOD == 1){
     for (c in 1:N_conc_measurement){
-      print(yconc[c], conc[experiment_yconc[c], mic_ix_yconc[c]]);
       target += lognormal_lpdf(yconc[c] | log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
     }
     for (ec in 1:N_enzyme_measurement){

--- a/src/maud/stan_code/inference_model_lower_blocks.stan
+++ b/src/maud/stan_code/inference_model_lower_blocks.stan
@@ -11,6 +11,8 @@ data {
   int<lower=1> N_conc_measurement;
   int<lower=1> N_metabolite;  // NB metabolites in multiple compartments only count once here
   // measurements
+  int<lower=1,upper=N_mic> unbalanced_mic_ix[N_unbalanced];
+  int<lower=1,upper=N_mic> balanced_mic_ix[N_mic-N_unbalanced];
   int<lower=1,upper=N_experiment> experiment_yconc[N_conc_measurement];
   int<lower=1,upper=N_mic> mic_ix_yconc[N_conc_measurement];
   vector[N_conc_measurement] yconc;
@@ -28,10 +30,10 @@ data {
   vector<lower=0>[N_metabolite] prior_scale_formation_energy;
   vector[N_kinetic_parameters] prior_loc_kinetic_parameters;
   vector<lower=0>[N_kinetic_parameters] prior_scale_kinetic_parameters;
-  real prior_loc_conc[N_mic, N_experiment];
-  real<lower=0> prior_scale_conc[N_mic, N_experiment];
-  real prior_loc_enzyme[N_enzyme, N_experiment];
-  real<lower=0> prior_scale_enzyme[N_enzyme, N_experiment];
+  real prior_loc_unbalanced[N_experiment, N_unbalanced];
+  real<lower=0> prior_scale_unbalanced[N_experiment, N_unbalanced];
+  real prior_loc_enzyme[N_experiment, N_enzyme];
+  real<lower=0> prior_scale_enzyme[N_experiment, N_enzyme];
   // network properties
   matrix[N_mic, N_enzyme] stoichiometric_matrix;
   int<lower=1,upper=N_metabolite> metabolite_ix_stoichiometric_matrix[N_mic];
@@ -51,19 +53,18 @@ parameters {
   vector[N_metabolite] formation_energy;
   vector<lower=0>[N_kinetic_parameters] kinetic_parameters;
   vector<lower=0>[N_enzyme] enzyme_concentration[N_experiment];
+  vector<lower=0>[N_unbalanced] conc_unbalanced[N_experiment];
 }
 transformed parameters {
   vector<lower=0>[N_mic] conc[N_experiment];
   vector[N_reaction] flux[N_experiment];
-  vector[N_enzyme] delta_g = stoichiometric_matrix' * formation_energy[metabolite_ix_stoiciometric_matrix];
+  vector[N_enzyme] delta_g = stoichiometric_matrix' * formation_energy[metabolite_ix_stoichiometric_matrix];
   for (e in 1:N_experiment){
     vector[N_enzyme] keq = exp(delta_g / minus_RT);
-    vector[N_unbalanced+N_enzyme+N_enzyme+N_kinetic_parameters] theta;
-    theta[1:N_unbalanced] = conc[e, { {{-unbalanced_codes|join(',')-}} }];
-    theta[N_unbalanced+1:N_unbalanced+N_enzyme] = enzyme_concentration[e];
-    theta[N_unbalanced+N_enzyme+1:N_unbalanced+N_enzyme+N_enzyme] = keq;
-    theta[N_unbalanced+N_enzyme+N_enzyme+1:] = kinetic_parameters;
-    conc[e, { {{-balanced_codes|join(',')-}} }] = algebra_solver(steady_state_function, as_guess, theta, xr, xi, rtol, ftol, steps);
+    vector[N_unbalanced+N_enzyme+N_enzyme+N_kinetic_parameters] theta = append_row(append_row(append_row(
+      conc_unbalanced[e], enzyme_concentration[e]), keq), kinetic_parameters);
+    conc[e, balanced_mic_ix] = algebra_solver(steady_state_function, as_guess, theta, xr, xi, rtol, ftol, steps);
+    conc[e, unbalanced_mic_ix] = conc_unbalanced[e];
     flux[e] = get_fluxes(to_array_1d(conc[e]), to_array_1d(theta));
   }
 }
@@ -71,13 +72,13 @@ model {
   kinetic_parameters ~ lognormal(log(prior_loc_kinetic_parameters), prior_scale_kinetic_parameters);
   formation_energy ~ normal(prior_loc_formation_energy, prior_scale_formation_energy);
   for (e in 1:N_experiment){
-    conc[e] ~ lognormal(log(prior_loc_conc[,e]), prior_scale_conc[,e]);
-    enzyme_concentration[e] ~ lognormal(log(prior_loc_enzyme[,e]), prior_scale_enzyme[,e]);
+    conc_unbalanced[e] ~ lognormal(log(prior_loc_unbalanced[e]), prior_scale_unbalanced[e]);
+    enzyme_concentration[e] ~ lognormal(log(prior_loc_enzyme[e]), prior_scale_enzyme[e]);
   }
   if (LIKELIHOOD == 1){
     for (c in 1:N_conc_measurement){
-      print(yconc[c], conc[experiment_yconc[c], metabolite_yconc[c]]);
-      target += lognormal_lpdf(yconc[c] | log(conc[experiment_yconc[c], metabolite_yconc[c]]), sigma_conc[c]);
+      print(yconc[c], conc[experiment_yconc[c], mic_ix_yconc[c]]);
+      target += lognormal_lpdf(yconc[c] | log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
     }
     for (ec in 1:N_enzyme_measurement){
       target += lognormal_lpdf(yenz[ec] | log(enzyme_concentration[experiment_yenz[ec], enzyme_yenz[ec]]), sigma_enz[ec]);
@@ -92,7 +93,7 @@ generated quantities {
   vector[N_enzyme_measurement] yenz_sim;
   vector[N_flux_measurement] yflux_sim;
   for (c in 1:N_conc_measurement){
-    yconc_sim[c] = lognormal_rng(log(conc[experiment_yconc[c], metabolite_yconc[c]]), sigma_conc[c]);
+    yconc_sim[c] = lognormal_rng(log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
   }
   for (ec in 1:N_enzyme_measurement){
     yenz_sim[ec] = lognormal_rng(log(enzyme_concentration[experiment_yenz[ec], enzyme_yenz[ec]]), sigma_enz[ec]);

--- a/tests/data/linear.json
+++ b/tests/data/linear.json
@@ -1,0 +1,228 @@
+{
+    "N_mic": 4,
+    "N_unbalanced": 2,
+    "N_kinetic_parameters": 14,
+    "N_reaction": 3,
+    "N_enzyme": 3,
+    "N_experiment": 2,
+    "N_flux_measurement": 2,
+    "N_enzyme_measurement": 6,
+    "N_conc_measurement": 8,
+    "N_metabolite": 2,
+    "stoichiometric_matrix": [
+        [
+            -1,
+            0,
+            0
+        ],
+        [
+            0,
+            0,
+            1
+        ],
+        [
+            1,
+            -1,
+            0
+        ],
+        [
+            0,
+            1,
+            -1
+        ]
+    ],
+    "metabolite_ix_stoichiometric_matrix": [
+        1,
+        2,
+        1,
+        2
+    ],
+    "experiment_yconc": [
+        1,
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        2
+    ],
+    "mic_ix_yconc": [
+        3,
+        4,
+        1,
+        2,
+        3,
+        4,
+        1,
+        2
+    ],
+    "balanced_mic_ix": [
+        3,
+        4
+    ],
+    "unbalanced_mic_ix": [
+        1,
+        2
+    ],
+    "yconc": [
+        0.8,
+        1.5,
+        2.0,
+        1.0,
+        0.7,
+        1.4,
+        2.0,
+        1.0
+    ],
+    "sigma_conc": [
+        0.1,
+        0.1,
+        0.05,
+        0.05,
+        0.1,
+        0.1,
+        0.05,
+        0.05
+    ],
+    "experiment_yflux": [
+        1,
+        2
+    ],
+    "reaction_yflux": [
+        3,
+        3
+    ],
+    "yflux": [
+        0.29,
+        0.21
+    ],
+    "sigma_flux": [
+        0.1,
+        0.1
+    ],
+    "experiment_yenz": [
+        1,
+        1,
+        1,
+        2,
+        2,
+        2
+    ],
+    "enzyme_yenz": [
+        1,
+        2,
+        3,
+        1,
+        2,
+        3
+    ],
+    "yenz": [
+        1.0,
+        1.0,
+        1.0,
+        1.5,
+        1.5,
+        1.5
+    ],
+    "sigma_enz": [
+        0.05,
+        0.05,
+        0.05,
+        0.05,
+        0.05,
+        0.05
+    ],
+    "prior_loc_formation_energy": [
+        -1,
+        -2
+    ],
+    "prior_scale_formation_energy": [
+        0.05,
+        0.05
+    ],
+    "prior_loc_kinetic_parameters": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+    ],
+    "prior_scale_kinetic_parameters": [
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6,
+        0.6
+    ],
+    "prior_loc_unbalanced": [
+        [
+            1,
+            1
+        ],
+        [
+            1,
+            1
+        ]
+    ],
+    "prior_scale_unbalanced": [
+        [
+            4,
+            4
+        ],
+        [
+            4,
+            4
+        ]
+    ],
+    "prior_loc_enzyme": [
+        [
+            0.1,
+            0.1,
+            0.1
+        ],
+        [
+            0.1,
+            0.1,
+            0.1
+        ]
+    ],
+    "prior_scale_enzyme": [
+        [
+            3,
+            3,
+            3
+        ],
+        [
+            3,
+            3,
+            3
+        ]
+    ],
+    "as_guess": [
+        0.01,
+        0.01
+    ],
+    "rtol": 1e-09,
+    "ftol": 1e-06,
+    "steps": 1000000000,
+    "LIKELIHOOD": 1
+}

--- a/tests/data/linear.stan
+++ b/tests/data/linear.stan
@@ -163,7 +163,6 @@ model {
   }
   if (LIKELIHOOD == 1){
     for (c in 1:N_conc_measurement){
-      print(yconc[c], conc[experiment_yconc[c], mic_ix_yconc[c]]);
       target += lognormal_lpdf(yconc[c] | log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
     }
     for (ec in 1:N_enzyme_measurement){

--- a/tests/data/linear.stan
+++ b/tests/data/linear.stan
@@ -86,7 +86,7 @@ real Dr_reg_r3 = 0;
 }
 data {
   // dimensions
-  int<lower=1> N_balanced;    // 'Balanced' metabolites must have constant concentration at steady state
+  int<lower=1> N_mic;         // Total number of metabolites in compartments
   int<lower=1> N_unbalanced;  // 'Unbalanced' metabolites can have changing concentration at steady state
   int<lower=1> N_kinetic_parameters;
   int<lower=1> N_reaction;
@@ -97,8 +97,10 @@ data {
   int<lower=1> N_conc_measurement;
   int<lower=1> N_metabolite;  // NB metabolites in multiple compartments only count once here
   // measurements
+  int<lower=1,upper=N_mic> unbalanced_mic_ix[N_unbalanced];
+  int<lower=1,upper=N_mic> balanced_mic_ix[N_mic-N_unbalanced];
   int<lower=1,upper=N_experiment> experiment_yconc[N_conc_measurement];
-  int<lower=1,upper=N_balanced+N_unbalanced> metabolite_yconc[N_conc_measurement];
+  int<lower=1,upper=N_mic> mic_ix_yconc[N_conc_measurement];
   vector[N_conc_measurement] yconc;
   vector<lower=0>[N_conc_measurement] sigma_conc;
   int<lower=1,upper=N_experiment> experiment_yflux[N_flux_measurement];
@@ -114,15 +116,15 @@ data {
   vector<lower=0>[N_metabolite] prior_scale_formation_energy;
   vector[N_kinetic_parameters] prior_loc_kinetic_parameters;
   vector<lower=0>[N_kinetic_parameters] prior_scale_kinetic_parameters;
-  real prior_loc_unbalanced[N_unbalanced, N_experiment];
-  real<lower=0> prior_scale_unbalanced[N_unbalanced, N_experiment];
-  real prior_loc_enzyme[N_enzyme, N_experiment];
-  real<lower=0> prior_scale_enzyme[N_enzyme, N_experiment];
+  real prior_loc_unbalanced[N_experiment, N_unbalanced];
+  real<lower=0> prior_scale_unbalanced[N_experiment, N_unbalanced];
+  real prior_loc_enzyme[N_experiment, N_enzyme];
+  real<lower=0> prior_scale_enzyme[N_experiment, N_enzyme];
   // network properties
-  matrix[N_balanced+N_unbalanced, N_enzyme] stoichiometric_matrix;
-  int<lower=1,upper=N_metabolite> compartment_metabolite_index[N_balanced+N_unbalanced];
+  matrix[N_mic, N_enzyme] stoichiometric_matrix;
+  int<lower=1,upper=N_metabolite> metabolite_ix_stoichiometric_matrix[N_mic];
   // configuration
-  vector<lower=0>[N_balanced] as_guess;
+  vector<lower=0>[N_mic-N_unbalanced] as_guess;
   real rtol;
   real ftol;
   int steps;
@@ -136,22 +138,19 @@ transformed data {
 parameters {
   vector[N_metabolite] formation_energy;
   vector<lower=0>[N_kinetic_parameters] kinetic_parameters;
-  vector<lower=0>[N_unbalanced] unbalanced[N_experiment];
   vector<lower=0>[N_enzyme] enzyme_concentration[N_experiment];
+  vector<lower=0>[N_unbalanced] conc_unbalanced[N_experiment];
 }
 transformed parameters {
-  vector<lower=0>[N_balanced+N_unbalanced] conc[N_experiment];
+  vector<lower=0>[N_mic] conc[N_experiment];
   vector[N_reaction] flux[N_experiment];
-  vector[N_enzyme] delta_g = stoichiometric_matrix' * formation_energy[compartment_metabolite_index];
+  vector[N_enzyme] delta_g = stoichiometric_matrix' * formation_energy[metabolite_ix_stoichiometric_matrix];
   for (e in 1:N_experiment){
     vector[N_enzyme] keq = exp(delta_g / minus_RT);
-    vector[N_unbalanced+N_enzyme+N_enzyme+N_kinetic_parameters] theta;
-    theta[1:N_unbalanced] = unbalanced[e];
-    theta[N_unbalanced+1:N_unbalanced+N_enzyme] = enzyme_concentration[e];
-    theta[N_unbalanced+N_enzyme+1:N_unbalanced+N_enzyme+N_enzyme] = keq;
-    theta[N_unbalanced+N_enzyme+N_enzyme+1:] = kinetic_parameters;
-    conc[e, {3,4}] = algebra_solver(steady_state_function, as_guess, theta, xr, xi, rtol, ftol, steps);
-    conc[e, {1,2}] = unbalanced[e];
+    vector[N_unbalanced+N_enzyme+N_enzyme+N_kinetic_parameters] theta = append_row(append_row(append_row(
+      conc_unbalanced[e], enzyme_concentration[e]), keq), kinetic_parameters);
+    conc[e, balanced_mic_ix] = algebra_solver(steady_state_function, as_guess, theta, xr, xi, rtol, ftol, steps);
+    conc[e, unbalanced_mic_ix] = conc_unbalanced[e];
     flux[e] = get_fluxes(to_array_1d(conc[e]), to_array_1d(theta));
   }
 }
@@ -159,12 +158,13 @@ model {
   kinetic_parameters ~ lognormal(log(prior_loc_kinetic_parameters), prior_scale_kinetic_parameters);
   formation_energy ~ normal(prior_loc_formation_energy, prior_scale_formation_energy);
   for (e in 1:N_experiment){
-    unbalanced[e] ~ lognormal(log(prior_loc_unbalanced[,e]), prior_scale_unbalanced[,e]);
-    enzyme_concentration[e] ~ lognormal(log(prior_loc_enzyme[,e]), prior_scale_enzyme[,e]);
+    conc_unbalanced[e] ~ lognormal(log(prior_loc_unbalanced[e]), prior_scale_unbalanced[e]);
+    enzyme_concentration[e] ~ lognormal(log(prior_loc_enzyme[e]), prior_scale_enzyme[e]);
   }
   if (LIKELIHOOD == 1){
     for (c in 1:N_conc_measurement){
-      target += lognormal_lpdf(yconc[c] | log(conc[experiment_yconc[c], metabolite_yconc[c]]), sigma_conc[c]);
+      print(yconc[c], conc[experiment_yconc[c], mic_ix_yconc[c]]);
+      target += lognormal_lpdf(yconc[c] | log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
     }
     for (ec in 1:N_enzyme_measurement){
       target += lognormal_lpdf(yenz[ec] | log(enzyme_concentration[experiment_yenz[ec], enzyme_yenz[ec]]), sigma_enz[ec]);
@@ -179,7 +179,7 @@ generated quantities {
   vector[N_enzyme_measurement] yenz_sim;
   vector[N_flux_measurement] yflux_sim;
   for (c in 1:N_conc_measurement){
-    yconc_sim[c] = lognormal_rng(log(conc[experiment_yconc[c], metabolite_yconc[c]]), sigma_conc[c]);
+    yconc_sim[c] = lognormal_rng(log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
   }
   for (ec in 1:N_enzyme_measurement){
     yenz_sim[ec] = lognormal_rng(log(enzyme_concentration[experiment_yenz[ec], enzyme_yenz[ec]]), sigma_enz[ec]);

--- a/tests/test_unit/test_io.py
+++ b/tests/test_unit/test_io.py
@@ -11,6 +11,31 @@ data_path = os.path.join(here, "../data")
 
 def test_load_maud_input_from_toml():
     """Test that the function load_maud_input_from_toml behaves as expected."""
+    expected_stan_codes = {
+        "metabolite": {"M1": 1, "M2": 2},
+        "metabolite_in_compartment": {"M1_e": 1, "M2_e": 2, "M1_c": 3, "M2_c": 4},
+        "balanced_mic": {"M1_c": 3, "M2_c": 4},
+        "unbalanced_mic": {"M1_e": 1, "M2_e": 2},
+        "kinetic_parameter": {
+            "r1_Ka": 1,
+            "r1_Kp": 2,
+            "r1_Kcat1": 3,
+            "r1_dissociation_constant_r_M2_c": 4,
+            "r1_transfer_constant": 5,
+            "r2_Ka": 6,
+            "r2_Kp": 7,
+            "r2_Kcat1": 8,
+            "r2_dissociation_constant_t_M1_c": 9,
+            "r2_transfer_constant": 10,
+            "r2_inhibition_constant_M2_c": 11,
+            "r3_Ka": 12,
+            "r3_Kp": 13,
+            "r3_Kcat1": 14,
+        },
+        "reaction": {"r1": 1, "r2": 2, "r3": 3},
+        "experiment": {"condition_1": 1, "condition_2": 2},
+        "enzyme": {"r1": 1, "r2": 2, "r3": 3},
+    }
     mi = io.load_maud_input_from_toml(os.path.join(data_path, "linear.toml"))
     assert mi.kinetic_model.reactions["r1"].stoichiometry == {"M1_e": -1, "M1_c": 1}
     print(mi.priors["r1_Kcat1"].target_id)
@@ -19,3 +44,4 @@ def test_load_maud_input_from_toml():
         mi.experiments["condition_1"].measurements["metabolite"]["M1_c"].target_type
         == "metabolite"
     )
+    assert mi.stan_codes == expected_stan_codes

--- a/tests/test_unit/test_sampling.py
+++ b/tests/test_unit/test_sampling.py
@@ -1,5 +1,6 @@
 """Unit tests for sampling functions."""
 
+import json
 import os
 
 from numpy.testing import assert_equal
@@ -13,77 +14,9 @@ data_path = os.path.join(here, "../data")
 
 def test_get_input_data():
     """Test that the function get_input_data behaves as expected."""
-    expected = {
-        "N_balanced": 2,
-        "N_unbalanced": 2,
-        "N_kinetic_parameters": 14,
-        "N_reaction": 3,
-        "N_enzyme": 3,
-        "N_experiment": 2,
-        "N_flux_measurement": 2,
-        "N_enzyme_measurement": 6,
-        "N_conc_measurement": 8,
-        "N_metabolite": 2,
-        "stoichiometric_matrix": [[-1, 0, 0], [0, 0, 1], [1, -1, 0], [0, 1, -1]],
-        "compartment_metabolite_index": [1, 2, 1, 2],
-        "experiment_yconc": [1, 1, 1, 1, 2, 2, 2, 2],
-        "metabolite_yconc": [3, 4, 1, 2, 3, 4, 1, 2],
-        "yconc": [0.8, 1.5, 2.0, 1.0, 0.7, 1.4, 2.0, 1.0],
-        "sigma_conc": [0.1, 0.1, 0.05, 0.05, 0.1, 0.1, 0.05, 0.05],
-        "experiment_yflux": [1, 2],
-        "reaction_yflux": [3, 3],
-        "yflux": [0.29, 0.21],
-        "sigma_flux": [0.1, 0.1],
-        "experiment_yenz": [1, 1, 1, 2, 2, 2],
-        "enzyme_yenz": [1, 2, 3, 1, 2, 3],
-        "yenz": [1.0, 1.0, 1.0, 1.5, 1.5, 1.5],
-        "sigma_enz": [0.05, 0.05, 0.05, 0.05, 0.05, 0.05],
-        "prior_loc_formation_energy": [-1.0, -2.0],
-        "prior_scale_formation_energy": [0.05, 0.05],
-        "prior_loc_kinetic_parameters": [
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-        ],
-        "prior_scale_kinetic_parameters": [
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-            0.6,
-        ],
-        "prior_loc_unbalanced": [[0.1, 0.1], [0.1, 0.1]],
-        "prior_scale_unbalanced": [[1, 1], [1, 1]],
-        "prior_loc_enzyme": [[0.1, 0.1], [0.1, 0.1], [0.1, 0.1]],
-        "prior_scale_enzyme": [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]],
-        "as_guess": [0.01, 0.01],
-        "rtol": 1e-09,
-        "ftol": 1e-06,
-        "steps": 1000000000,
-        "LIKELIHOOD": 1,
-    }
     toml_input_path = os.path.join(data_path, "linear.toml")
     mi = io.load_maud_input_from_toml(toml_input_path)
+    expected = json.load(open(os.path.join(data_path, "linear.json"), "r"))
     actual = sampling.get_input_data(mi, 1e-06, 1e-09, int(1e9), 1)
     assert actual.keys() == expected.keys()
     for k in actual.keys():


### PR DESCRIPTION
This change improves the process of passing indexes to Stan, sets better initial values for unbalanced metabolite concentration parameters and tidies up the tests a little.

Stan indexes are now created once when the MaudInput object is loaded using the new `get_stan_codes`. The modules that need stan codes now load them rather than recalculating them. This makes it less likely that they will disagree, which it turns out is happening at the moment.

Initial values for unbalanced metabolite concentrations are now set to measured values where these are available. This resulted in much higher joint log probability for the yeast model. For external glucose the measurement was about 73 and the initial value was 0.1 (and the posterior is probably quite hard to explore with all the non-linear dynamics) so it's plausible that the sampler was getting stuck with the previous initial values and couldn't find the typical set.