### PR TITLE
Remove non-modular rate laws

### DIFF
--- a/docs/adr/0010-modular-rate-law-only.md
+++ b/docs/adr/0010-modular-rate-law-only.md
@@ -1,0 +1,28 @@
+# 10. Use only modular rate laws
+
+Date: 2020-02-05
+
+## Status
+
+Accepted
+
+## Context
+
+The `code_generation.py` module is probably the ugliest part of Maud,
+particularly the function `create_fluxes_function`. It could be cleaned up a
+bit by removing non-modular enzyme mechanisms.
+
+Non-modular mechanisms aren't used in any of the models we are currently
+testing, but for historical reasons the logic in `code_generation.py` basically
+assumes that they are the default. The modular rate law is kind of an
+add-on. This change would let us move towards switching this around, having the
+modular rate law as the default and working in other mechanisms as and when
+necessary.
+
+## Decision
+
+We remove non-modular rate laws from the `code_generation.py` module.
+
+## Consequences
+
+We won't be able to use non-modular rate laws without writing them back in.

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -250,11 +250,7 @@ def create_fluxes_function(mi: MaudInput, template: Template) -> str:
                 mod.mic for mod in enz.modifiers.values()
                 if "competitive_inhibitor" in mod.modifier_type
             ]
-            (
-                substrate_block,
-                product_block,
-                competitor_block,
-            ) = get_modular_rate_codes(
+            mod_substrates, mod_products, mod_competitors = get_modular_rate_codes(
                 enz_id,
                 competitor_ids,
                 substrate_stoichiometries,
@@ -267,9 +263,9 @@ def create_fluxes_function(mi: MaudInput, template: Template) -> str:
                 enz=enz_code,
                 Kcat1=kp_codes_in_theta[enz_id + "_" + "Kcat1"],
                 Keq=keq_codes_in_theta[enz_id],
-                substrate_list=substrate_block,
-                product_list=product_block,
-                competitive_inhibitor_list=competitor_block,
+                substrate_list=mod_substrates,
+                product_list=mod_products,
+                competitive_inhibitor_list=mod_competitors,
             )
             modular_lines.append(modular_line)
             # make catalytic effect string
@@ -279,12 +275,9 @@ def create_fluxes_function(mi: MaudInput, template: Template) -> str:
                 if enz_id in k
             }
             enz_code = enz_codes[enz.id]
-            mechanism_args = {
-                "Tr": f"Tr_{enz_id}",
-                "Dr": f"Dr_{enz_id}",
-                "Dr_reg": f"Dr_reg_{enz_id}",
-            }
-            catalytic_string = MECHANISM_TEMPLATES[enz.mechanism].render(mechanism_args)
+            catalytic_string = (
+                f"modular_rate_law(Tr_{enz_id}, Dr_{enz_id}, Dr_reg_{enz_id})"
+            )
             if any([mod.allosteric for mod in enz.modifiers.values()]):
                 # make free enzyme ratio line
                 free_enzyme_ratio_line = Template(

--- a/tests/data/linear.stan
+++ b/tests/data/linear.stan
@@ -45,12 +45,12 @@ real Dr_r3 = (1 + m[4]/p[20])^(-1*-1)
 
 
 real Dr_reg_r3 = 0;
-  real free_enzyme_ratio_r1 = get_free_enzyme_ratio_modular_rate_law(Tr_r1,Dr_r1, Dr_reg_r1);
-  real free_enzyme_ratio_r2 = get_free_enzyme_ratio_modular_rate_law(Tr_r2,Dr_r2, Dr_reg_r2);
+  real free_enzyme_ratio_r1 = get_free_enzyme_ratio_modular_rate_law(Tr_r1, Dr_r1, Dr_reg_r1);
+  real free_enzyme_ratio_r2 = get_free_enzyme_ratio_modular_rate_law(Tr_r2, Dr_r2, Dr_reg_r2);
   return [
-    modular_rate_law(Tr_r1,Dr_r1, Dr_reg_r1)*get_regulatory_effect({m[4]},empty_array,free_enzyme_ratio_r1,{p[12]},empty_array,p[13]),
-    modular_rate_law(Tr_r2,Dr_r2, Dr_reg_r2)*get_regulatory_effect(empty_array,{m[3]},free_enzyme_ratio_r2,empty_array,{p[17]},p[18]),
-    modular_rate_law(Tr_r3,Dr_r3, Dr_reg_r3)
+    modular_rate_law(Tr_r1, Dr_r1, Dr_reg_r1)*get_regulatory_effect({m[4]},empty_array,free_enzyme_ratio_r1,{p[12]},empty_array,p[13]),
+    modular_rate_law(Tr_r2, Dr_r2, Dr_reg_r2)*get_regulatory_effect(empty_array,{m[3]},free_enzyme_ratio_r2,empty_array,{p[17]},p[18]),
+    modular_rate_law(Tr_r3, Dr_r3, Dr_reg_r3)
   ]';
 }
   real[] ode_func(real t, real[] m, real[] p, real[] xr, int[] xi){

--- a/tests/test_unit/test_code_generation.py
+++ b/tests/test_unit/test_code_generation.py
@@ -27,24 +27,6 @@ def test_create_stan_program():
             assert c == generated_lines[i]
 
 
-def test_create_haldane_line():
-    """Test that the function create_haldane_line behaves as expected."""
-    rxn_id = "tr"
-    mechanism = "ordered_unibi"
-    param_codes = {
-        "tr_delta_g": 1,
-        "tr_Kia": 2,
-        "tr_Kq": 3,
-        "tr_Kcat1": 4,
-        "tr_Kcat2": 5,
-    }
-    expected_line = "real tr_Kip = get_Kip_ordered_unibi(p[1],p[2],p[3],p[4],p[5]);"
-    generated_line = code_generation.create_haldane_line(
-        param_codes, "Kip", mechanism, rxn_id, code_generation.HALDANE_PARAMS
-    )
-    assert generated_line == expected_line
-
-
 def test_get_regulatory_string():
     """Test that the function get_regulatory_string behaves as expected."""
     inhibitor_codes = {"m1": 1, "m2": 2}
@@ -64,54 +46,6 @@ def test_get_regulatory_string():
         ")"
     )
     assert generated == expected
-
-
-def test_mechanism_templates():
-    """Test that mechanism templates are as expected."""
-    codes = {
-        "S0": 1,
-        "S1": 2,
-        "S2": 3,
-        "P0": 4,
-        "P1": 5,
-        "enz": 1,
-        "Keq": 2,
-        "Kcat1": 3,
-        "Kcat2": 4,
-        "Ka": 5,
-        "Kb": 6,
-        "Kc": 7,
-        "Kp": 8,
-        "Kq": 9,
-        "Kia": 10,
-        "Kib": 11,
-        "Kic": 12,
-        "Kiq": 13,
-        "Tr": 1,
-        "Dr": 2,
-        "Dr_reg": 0,
-    }
-    enzyme_id = "e1"
-    expected_calls = {
-        "uniuni": "uniuni(m[1],m[4],p[1]*p[3],p[1]*p[4],p[5],p[2])",
-        "ordered_unibi": "ordered_unibi(m[1],m[4],m[5],p[1]*p[3],p[1]*p[4],p[5],"
-        "p[8],p[9],p[10],e1_Kip,e1_Kiq,p[2])",
-        "ordered_bibi": "ordered_bibi(m[1],m[2],m[4],m[5],p[1]*p[3],p[1]*p[4],"
-        "p[5],p[6],p[8],p[9],e1_Kia,p[11],e1_Kip,p[13],p[2])",
-        "pingpong": "pingpong(m[1],m[2],m[4],m[5],p[1]*p[3],p[1]*p[4],p[5],p[6],"
-        "p[8],p[9],p[10],p[11],e1_Kip,p[13],p[2])",
-        "ordered_terbi": "ordered_terbi(m[1],m[2],m[3],m[4],m[5],p[1]*p[3],"
-        "p[1]*p[4],p[5],p[6],p[7],e1_Kp,p[9],p[10],p[11],p[12],e1_Kip,p[13],p[2])",
-        "modular_rate_law": "modular_rate_law(1,2, 0)",
-    }
-    generated_calls = {
-        mechanism: template.render({**codes, **{"enz_id": enzyme_id}})
-        for mechanism, template in code_generation.MECHANISM_TEMPLATES.items()
-    }
-    print(generated_calls)
-    for mechanism, generated_call in generated_calls.items():
-        expected_call = expected_calls[mechanism]
-        assert generated_call == expected_call
 
 
 def test_get_modular_rate_codes():


### PR DESCRIPTION
This change gets rid of support for non-modular rate laws, which aren't being used in the models we are actively developing. 

The aim is to make the `code_generation.py` module easier to understand, and to make it easier to refactor the code generation logic without having to worry about having to worry about breaking these mechanisms.

I've added an adr document explaining the rationale in a bit more detail. I've put the status as 'accepted' but that is on the assumption that it passes code review. If you disagree with the change feel free to reject or discuss!
