### PR TITLE
Bug: new cmdstan interface ruins current ODE solver

### DIFF
--- a/src/maud/stan_code/steady_state_function.stan
+++ b/src/maud/stan_code/steady_state_function.stan
@@ -1,4 +1,4 @@
-vector steady_state_function(vector balanced, vector theta, real[] xr, int[] xi){
+vector steady_state_function(vector balanced, vector theta, data real[] xr, data int[] xi){
   int N_unbalanced = {{N_unbalanced}};
   int N_balanced = {{N_balanced}};
   real initial_time = 0;


### PR DESCRIPTION
Just updating argument spceifications,  if you update cmdstand the current master won't work. Can someone please check to see if it works on cmdstan version 2.22.0? This works on 2.22.1