### PR TITLE
Update steady state arguments

### DIFF
--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -96,9 +96,7 @@ pass
     default=SAMPLING_DEFAULTS["time_step"],
     help="How far ahead the ode solver simulates",
 )
-@click.option(
-    "--output_dir", default=".", help="Where to save Maud's output",
-)
+@click.option("--output_dir", default=".", help="Where to save Maud's output")
 @click.argument(
     "data_path",
     type=click.Path(exists=True, dir_okay=False),

--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -41,9 +41,7 @@ class Metabolite:
     :param name: metabolite name.
     """
 
-    def __init__(
-        self, id: str, name: str = None,
-    ):
+    def __init__(self, id: str, name: str = None):
         self.id = id
         self.name = name if name is not None else id
 

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -27,10 +27,7 @@ from maud import code_generation, io, utils
 from maud.data_model import KineticModel, MaudInput
 
 
-RELATIVE_PATHS = {
-    "stan_includes": "stan_code",
-    "autogen": "stan_code/autogen",
-}
+RELATIVE_PATHS = {"stan_includes": "stan_code", "autogen": "stan_code/autogen"}
 DEFAULT_PRIOR_LOC_UNBALANCED = 1
 DEFAULT_PRIOR_SCALE_UNBALANCED = 4
 DEFAULT_PRIOR_LOC_ENZYME = 0.1

--- a/src/maud/stan_code/steady_state_function.stan
+++ b/src/maud/stan_code/steady_state_function.stan
@@ -1,4 +1,4 @@
-vector steady_state_function(vector balanced, vector theta, real[] xr, int[] xi){
+vector steady_state_function(vector balanced, vector theta, data real[] xr, data int[] xi){
   int N_unbalanced = {{N_unbalanced}};
   int N_balanced = {{N_balanced}};
   real initial_time = 0;

--- a/tests/data/linear.stan
+++ b/tests/data/linear.stan
@@ -62,7 +62,7 @@ real Dr_reg_r3 = 0;
     1*fluxes[2]-1*fluxes[3]
   };
 }
-  vector steady_state_function(vector balanced, vector theta, real[] xr, int[] xi){
+  vector steady_state_function(vector balanced, vector theta, data real[] xr, data int[] xi){
   int N_unbalanced = 2;
   int N_balanced = 2;
   real initial_time = 0;


### PR DESCRIPTION
The argument types for integrate_ode_bdf were updated in cmdstan 2.22.1. This PR addresses this problem and should work using the new cmdstan. Unsure if it will work with the previous cmdstan. However you have to delete the old one first, it's typically located in ~/.cmdstanpy. You can delete this and run the install_cmdstan command in your repository after installing the python packages specified in the repository. Just follow the install instructions and it'll work