### PR TITLE
test: make travis install cmdstan before running tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python: ["3.7"]
 sudo: false
-install: ["pip install -e .[development]"]
+install: ["pip install -e .[development] && install_cmdstan"]
 script: ["tox"]


### PR DESCRIPTION
This change adds cmdstan installation to the install step of the travis build so that we can properly test model compilation and sampling