### PR TITLE
Validate init enzymes

### DIFF
--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -20,7 +20,7 @@ import os
 
 import click
 
-from maud import sampling
+from maud import sampling, prior_check
 
 
 SAMPLING_DEFAULTS = {
@@ -107,3 +107,31 @@ def sample(data_path, **kwargs):
     stanfit = sampling.sample(data_path, **kwargs)
     stanfit.diagnose()
     print(stanfit.summary())
+
+
+@cli.command()
+@click.option(
+    "--n_samples",
+    default=SAMPLING_DEFAULTS["n_samples"],
+    help="Number of post-warmup posterior samples",
+)
+@click.option(
+    "--n_warmup", default=SAMPLING_DEFAULTS["n_warmup"], help="Number of warmup samples"
+)
+@click.option(
+    "--n_chains", default=SAMPLING_DEFAULTS["n_chains"], help="Number of MCMC chains"
+)
+@click.option(
+    "--n_cores",
+    default=SAMPLING_DEFAULTS["n_cores"],
+    help="Number of chains to run in parallel",
+)
+@click.option("--output_dir", default=".", help="Where to save Maud's output")
+@click.argument(
+    "data_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=get_example_path(RELATIVE_PATH_EXAMPLE),
+)
+def prior(data_path, **kwargs):
+    """Sample from the model defined by the data at data_path."""
+    stanfit = prior_check.prior_check(data_path, **kwargs)

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -20,7 +20,7 @@ import os
 
 import click
 
-from maud import sampling, prior_check
+from maud import prior_check, sampling
 
 
 SAMPLING_DEFAULTS = {
@@ -135,3 +135,5 @@ def sample(data_path, **kwargs):
 def prior(data_path, **kwargs):
     """Sample from the model defined by the data at data_path."""
     stanfit = prior_check.prior_check(data_path, **kwargs)
+    stanfit.diagnose()
+    print(stanfit.summary())

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -72,7 +72,7 @@ def create_stan_program(mi: MaudInput, model_type: str, time_step=0.05) -> str:
             Keq_position=keq_position,
         )
     elif model_type == "prior_check":
-            lower_blocks = templates["prior_model_lower_blocks"].render(
+        lower_blocks = templates["prior_model_lower_blocks"].render(
             balanced_codes=balanced_codes,
             unbalanced_codes=unbalanced_codes,
             Keq_position=keq_position,

--- a/src/maud/code_generation.py
+++ b/src/maud/code_generation.py
@@ -30,6 +30,7 @@ from maud.data_model import MaudInput
 
 TEMPLATE_FILES = [
     "inference_model_lower_blocks.stan",
+    "prior_model_lower_blocks.stan",
     "functions_block.stan",
     "ode_function.stan",
     "fluxes_function.stan",
@@ -66,6 +67,12 @@ def create_stan_program(mi: MaudInput, model_type: str, time_step=0.05) -> str:
     )
     if model_type == "inference":
         lower_blocks = templates["inference_model_lower_blocks"].render(
+            balanced_codes=balanced_codes,
+            unbalanced_codes=unbalanced_codes,
+            Keq_position=keq_position,
+        )
+    elif model_type == "prior_check":
+            lower_blocks = templates["prior_model_lower_blocks"].render(
             balanced_codes=balanced_codes,
             unbalanced_codes=unbalanced_codes,
             Keq_position=keq_position,

--- a/src/maud/prior_check.py
+++ b/src/maud/prior_check.py
@@ -146,7 +146,6 @@ def prior_check(
                 limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']}"""
             )
 
-    
     if flux_within_bounds:
         print("All fluxes appear within prior specification")
 

--- a/src/maud/prior_check.py
+++ b/src/maud/prior_check.py
@@ -115,18 +115,18 @@ def prior_check(
     )
 
     reaction_measurements = pd.DataFrame(
-            [
-                [exp.id, meas.target_id, meas.value, meas.uncertainty]
-                for exp in mi.experiments.values()
-                for meas in exp.measurements['reaction'].values()
-            ],
+        [
+            [exp.id, meas.target_id, meas.value, meas.uncertainty]
+            for exp in mi.experiments.values()
+            for meas in exp.measurements['reaction'].values()
+        ],
             columns=["experiment_id", "target_id", "value", "uncertainty"],
-        )
+    )
 
     for i, row in enumerate(reaction_measurements.iterrows()):
         if row[1]['value'] < model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']:
             print(f"""
-                {row[1]['target_id']} in experiment {row[1]['experiment_id']} 
+                {row[1]['target_id']} in experiment {row[1]['experiment_id']}
                 had a flux specified that was smaller than the prior flux\n
                 flux = {row[1]['value']} \
                 limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']}""")

--- a/src/maud/prior_check.py
+++ b/src/maud/prior_check.py
@@ -123,8 +123,11 @@ def prior_check(
         columns=["experiment_id", "target_id", "value", "uncertainty"],
     )
 
+    flux_within_bounds = 1
+
     for i, row in enumerate(reaction_measurements.iterrows()):
         if row[1]["value"] < model_fit.summary().loc[f"yflux_sim[{i+1}]", "5%"]:
+            flux_within_bounds = 0
             print(
                 f"""
                 {row[1]['target_id']} in experiment {row[1]['experiment_id']}
@@ -134,6 +137,7 @@ def prior_check(
             )
 
         if row[1]["value"] > model_fit.summary().loc[f"yflux_sim[{i+1}]", "95%"]:
+            flux_within_bounds = 1
             print(
                 f"""
                 {row[1]['target_id']} in experiment {row[1]['experiment_id']}
@@ -141,6 +145,10 @@ def prior_check(
                 flux = {row[1]['value']} \
                 limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']}"""
             )
+
+    
+    if flux_within_bounds:
+        print("All fluxes appear within prior specification")
 
     return model_fit
 

--- a/src/maud/prior_check.py
+++ b/src/maud/prior_check.py
@@ -125,16 +125,20 @@ def prior_check(
 
     for i, row in enumerate(reaction_measurements.iterrows()):
         if row[1]['value'] < model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']:
-            print(f"""{row[1]['target_id']} in experiment {row[1]['experiment_id']}
+            print(f"""
+                {row[1]['target_id']} in experiment {row[1]['experiment_id']} 
                 had a flux specified that was smaller than the prior flux\n
-                flux = {row[1]['value']} \t\t limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']}""")
+                flux = {row[1]['value']} \
+                limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']}""")
 
         if row[1]['value'] > model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']:
-            print(f"""{row[1]['target_id']} in experiment {row[1]['experiment_id']}
+            print(f"""
+                {row[1]['target_id']} in experiment {row[1]['experiment_id']}
                 had a flux specified that was larger than the prior flux\n
-                flux = {row[1]['value']} \t\t limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']}""")
+                flux = {row[1]['value']} \
+                limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']}""")
 
-    return
+    return model_fit
 
 
 def get_input_data(
@@ -169,8 +173,8 @@ def get_input_data(
     for p in mi.priors.values():
         if p.target_type == "metabolite_concentration":
             ix = [experiment_codes[mic_codes[p.target_id - 1], p.experiment_id] - 1]
-            prior_loc_unb[ix] = p.location
-            prior_scale_unb[ix] = p.scale
+            prior_loc_conc[ix] = p.location
+            prior_scale_conc[ix] = p.scale
     prior_loc_formation_energy = [
         mi.priors[k + "_formation_energy"].location for k in met_codes.keys()
     ]

--- a/src/maud/prior_check.py
+++ b/src/maud/prior_check.py
@@ -1,0 +1,239 @@
+# Copyright (C) 2019 Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Code for sampling from a posterior distribution."""
+
+import os
+from typing import Dict
+
+import cmdstanpy
+import numpy as np
+import pandas as pd
+
+from maud import code_generation, io, utils
+from maud.data_model import KineticModel, MaudInput
+
+
+INCLUDE_PATH = "stan_code"
+DEFAULT_PRIOR_LOC_UNBALANCED = 1
+DEFAULT_PRIOR_SCALE_UNBALANCED = 4
+DEFAULT_PRIOR_LOC_ENZYME = 0.1
+DEFAULT_PRIOR_SCALE_ENZYME = 3
+
+
+def get_full_stoichiometry(
+    kinetic_model: KineticModel,
+    enzyme_codes: Dict[str, int],
+    metabolite_codes: Dict[str, int],
+):
+    """Get full stoichiometric matrix for each isoenzyme.
+
+    :param kinetic_model: A Kinetic Model object
+    :param enzyme_codes: the codified enzyme codes
+    :param metabolite_codes: the codified metabolite codes
+    """
+    S = pd.DataFrame(index=enzyme_codes, columns=metabolite_codes)
+    for _, rxn in kinetic_model.reactions.items():
+        for enz_id, _ in rxn.enzymes.items():
+            for met, stoic in rxn.stoichiometry.items():
+                S.loc[enz_id, met] = stoic
+    S.fillna(0, inplace=True)
+    return S
+
+
+def prior_check(
+    data_path: str,
+    n_samples: int,
+    n_warmup: int,
+    n_chains: int,
+    n_cores: int,
+    output_dir: str,
+) -> cmdstanpy.CmdStanMCMC:
+    """Sample from a prior distribution.
+
+    :param data_path: A path to a toml file containing input data
+    :param n_samples: Number of post-warmup samples
+    :param n_warmup: Number of warmup samples
+    :param n_chains: Number of MCMC chains to run
+    :param n_cores: Number of cores to try and use
+    :param: output_dir: Directory to save output
+    """
+    model_name = os.path.splitext(os.path.basename(data_path))[0]
+    input_filepath = os.path.join(output_dir, f"input_data_prior_{model_name}.json")
+
+    here = os.path.dirname(os.path.abspath(__file__))
+
+    mi = io.load_maud_input_from_toml(data_path)
+
+    input_data = get_input_data(mi)
+
+    cmdstanpy.utils.jsondump(input_filepath, input_data)
+
+    stan_program_filename = f"prior_model_{model_name}.stan"
+    stan_program_filepath = os.path.join(output_dir, stan_program_filename)
+    exe_file_path = stan_program_filepath[:-5]
+    stan_code = code_generation.create_stan_program(mi, "prior_check")
+    exe_file_exists = os.path.exists(exe_file_path)
+    change_in_stan_code = not utils.match_string_to_file(
+        stan_code, stan_program_filepath
+    )
+    need_to_overwrite = (not exe_file_exists) or change_in_stan_code
+    if need_to_overwrite:
+        with open(stan_program_filepath, "w") as f:
+            f.write(stan_code)
+        for p in [exe_file_path, exe_file_path + ".o", exe_file_path + ".hpp"]:
+            if os.path.exists(p):
+                os.remove(p)
+    include_path = os.path.join(here, INCLUDE_PATH)
+    model = cmdstanpy.CmdStanModel(
+        stan_file=stan_program_filepath, stanc_options={"include_paths": [include_path]}
+    )
+
+    model_fit = model.sample(
+        data=input_filepath,
+        chains=n_chains,
+        cores=4,
+        iter_sampling=n_samples,
+        output_dir=output_dir,
+        iter_warmup=n_warmup,
+        max_treedepth=15,
+        save_warmup=True,
+        show_progress=True,
+    )
+
+    reaction_measurements = pd.DataFrame(
+            [
+                [exp.id, meas.target_id, meas.value, meas.uncertainty]
+                for exp in mi.experiments.values()
+                for meas in exp.measurements['reaction'].values()
+            ],
+            columns=["experiment_id", "target_id", "value", "uncertainty"],
+        )
+
+    for i, row in enumerate(reaction_measurements.iterrows()):
+        if row[1]['value'] < model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']:
+            print(f"""{row[1]['target_id']} in experiment {row[1]['experiment_id']}
+                had a flux specified that was smaller than the prior flux\n
+                flux = {row[1]['value']} \t\t limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']}""")
+
+        if row[1]['value'] > model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']:
+            print(f"""{row[1]['target_id']} in experiment {row[1]['experiment_id']}
+                had a flux specified that was larger than the prior flux\n
+                flux = {row[1]['value']} \t\t limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']}""")
+
+    return
+
+
+def get_input_data(
+    mi: MaudInput,
+) -> dict:
+    """Put a MaudInput and some config numbers into a Stan-friendly dictionary.
+
+    :param mi: a MaudInput object
+    """
+    metabolites = mi.kinetic_model.metabolites
+    mics = mi.kinetic_model.mics
+    reactions = mi.kinetic_model.reactions
+    reaction_codes = mi.stan_codes["reaction"]
+    enzyme_codes = mi.stan_codes["enzyme"]
+    kp_codes = mi.stan_codes["kinetic_parameter"]
+    experiment_codes = mi.stan_codes["experiment"]
+    met_codes = mi.stan_codes["metabolite"]
+    mic_codes = mi.stan_codes["metabolite_in_compartment"]
+    balanced_mic_codes = mi.stan_codes["balanced_mic"]
+    unbalanced_mic_codes = mi.stan_codes["unbalanced_mic"]
+    mic_to_met = {
+        mic_codes[mic.id]: met_codes[mic.metabolite_id] for mic in mics.values()
+    }
+    enzymes = {k: v for r in reactions.values() for k, v in r.enzymes.items()}
+    full_stoic = get_full_stoichiometry(mi.kinetic_model, enzyme_codes, mic_codes)
+    # priors
+    prior_loc_kp = [mi.priors[k].location for k in kp_codes.keys()]
+    prior_scale_kp = [mi.priors[k].scale for k in kp_codes.keys()]
+    mic_shape = len(mi.experiments), len(mic_codes)
+    prior_loc_conc = np.full(mic_shape, DEFAULT_PRIOR_LOC_UNBALANCED)
+    prior_scale_conc = np.full(mic_shape, DEFAULT_PRIOR_SCALE_UNBALANCED)
+    for p in mi.priors.values():
+        if p.target_type == "metabolite_concentration":
+            ix = [experiment_codes[mic_codes[p.target_id - 1], p.experiment_id] - 1]
+            prior_loc_unb[ix] = p.location
+            prior_scale_unb[ix] = p.scale
+    prior_loc_formation_energy = [
+        mi.priors[k + "_formation_energy"].location for k in met_codes.keys()
+    ]
+    prior_scale_formation_energy = [
+        mi.priors[k + "_formation_energy"].scale for k in met_codes.keys()
+    ]
+    enzyme_shape = len(mi.experiments), len(enzymes)
+    prior_loc_enzyme = np.full(enzyme_shape, DEFAULT_PRIOR_LOC_ENZYME)
+    prior_scale_enzyme = np.full(enzyme_shape, DEFAULT_PRIOR_SCALE_ENZYME)
+    # measurements
+    mic_measurements, reaction_measurements, enzyme_measurements = (
+        pd.DataFrame(
+            [
+                [exp.id, meas.target_id, meas.value, meas.uncertainty]
+                for exp in mi.experiments.values()
+                for meas in exp.measurements[measurement_type].values()
+            ],
+            columns=["experiment_id", "target_id", "value", "uncertainty"],
+        )
+        for measurement_type in ["metabolite", "reaction", "enzyme"]
+    )
+
+    return {
+        "N_mic": len(mics),
+        "N_unbalanced": len(unbalanced_mic_codes),
+        "N_kinetic_parameters": len(kp_codes),
+        "N_reaction": len(reactions),
+        "N_enzyme": len(enzymes),
+        "N_experiment": len(mi.experiments),
+        "N_flux_measurement": len(reaction_measurements),
+        "N_enzyme_measurement": len(enzyme_measurements),
+        "N_conc_measurement": len(mic_measurements),
+        "N_metabolite": len(metabolites),
+        "stoichiometric_matrix": full_stoic.T.values,
+        "metabolite_ix_stoichiometric_matrix": list(mic_to_met.values()),
+        "experiment_yconc": (
+            mic_measurements["experiment_id"].map(experiment_codes).values
+        ),
+        "mic_ix_yconc": mic_measurements["target_id"].map(mic_codes).values,
+        "balanced_mic_ix": list(balanced_mic_codes.values()),
+        "unbalanced_mic_ix": list(unbalanced_mic_codes.values()),
+        "yconc": mic_measurements["value"].values,
+        "sigma_conc": mic_measurements["uncertainty"].values,
+        "experiment_yflux": (
+            reaction_measurements["experiment_id"].map(experiment_codes).values
+        ),
+        "reaction_yflux": (
+            reaction_measurements["target_id"].map(reaction_codes).values
+        ),
+        "yflux": reaction_measurements["value"].values,
+        "sigma_flux": reaction_measurements["uncertainty"].values,
+        "experiment_yenz": (
+            enzyme_measurements["experiment_id"].map(experiment_codes).values
+        ),
+        "enzyme_yenz": (enzyme_measurements["target_id"].map(enzyme_codes).values),
+        "yenz": enzyme_measurements["value"].values,
+        "sigma_enz": enzyme_measurements["uncertainty"].values,
+        "prior_loc_formation_energy": prior_loc_formation_energy,
+        "prior_scale_formation_energy": prior_scale_formation_energy,
+        "prior_loc_kinetic_parameters": prior_loc_kp,
+        "prior_scale_kinetic_parameters": prior_scale_kp,
+        "prior_loc_conc": prior_loc_conc,
+        "prior_scale_conc": prior_scale_conc,
+        "prior_loc_enzyme": prior_loc_enzyme,
+        "prior_scale_enzyme": prior_scale_enzyme,
+    }

--- a/src/maud/prior_check.py
+++ b/src/maud/prior_check.py
@@ -118,32 +118,34 @@ def prior_check(
         [
             [exp.id, meas.target_id, meas.value, meas.uncertainty]
             for exp in mi.experiments.values()
-            for meas in exp.measurements['reaction'].values()
+            for meas in exp.measurements["reaction"].values()
         ],
-            columns=["experiment_id", "target_id", "value", "uncertainty"],
+        columns=["experiment_id", "target_id", "value", "uncertainty"],
     )
 
     for i, row in enumerate(reaction_measurements.iterrows()):
-        if row[1]['value'] < model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']:
-            print(f"""
+        if row[1]["value"] < model_fit.summary().loc[f"yflux_sim[{i+1}]", "5%"]:
+            print(
+                f"""
                 {row[1]['target_id']} in experiment {row[1]['experiment_id']}
                 had a flux specified that was smaller than the prior flux\n
                 flux = {row[1]['value']} \
-                limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']}""")
+                limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '5%']}"""
+            )
 
-        if row[1]['value'] > model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']:
-            print(f"""
+        if row[1]["value"] > model_fit.summary().loc[f"yflux_sim[{i+1}]", "95%"]:
+            print(
+                f"""
                 {row[1]['target_id']} in experiment {row[1]['experiment_id']}
                 had a flux specified that was larger than the prior flux\n
                 flux = {row[1]['value']} \
-                limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']}""")
+                limit = {model_fit.summary().loc[f'yflux_sim[{i+1}]', '95%']}"""
+            )
 
     return model_fit
 
 
-def get_input_data(
-    mi: MaudInput,
-) -> dict:
+def get_input_data(mi: MaudInput,) -> dict:
     """Put a MaudInput and some config numbers into a Stan-friendly dictionary.
 
     :param mi: a MaudInput object

--- a/src/maud/stan_code/prior_model_lower_blocks.stan
+++ b/src/maud/stan_code/prior_model_lower_blocks.stan
@@ -1,0 +1,93 @@
+data {
+  // dimensions
+  int<lower=1> N_mic;         // Total number of metabolites in compartments
+  int<lower=1> N_unbalanced;  // 'Unbalanced' metabolites can have changing concentration at steady state
+  int<lower=1> N_kinetic_parameters;
+  int<lower=1> N_reaction;
+  int<lower=1> N_enzyme;
+  int<lower=1> N_experiment;
+  int<lower=1> N_flux_measurement;
+  int<lower=1> N_enzyme_measurement;
+  int<lower=1> N_conc_measurement;
+  int<lower=1> N_metabolite;  // NB metabolites in multiple compartments only count once here
+  // measurements
+  int<lower=1,upper=N_mic> unbalanced_mic_ix[N_unbalanced];
+  int<lower=1,upper=N_mic> balanced_mic_ix[N_mic-N_unbalanced];
+  int<lower=1,upper=N_experiment> experiment_yconc[N_conc_measurement];
+  int<lower=1,upper=N_mic> mic_ix_yconc[N_conc_measurement];
+  vector[N_conc_measurement] yconc;
+  vector<lower=0>[N_conc_measurement] sigma_conc;
+  int<lower=1,upper=N_experiment> experiment_yflux[N_flux_measurement];
+  int<lower=1,upper=N_reaction> reaction_yflux[N_flux_measurement];
+  vector[N_flux_measurement] yflux;
+  vector<lower=0>[N_flux_measurement] sigma_flux;
+  int<lower=1,upper=N_experiment> experiment_yenz[N_enzyme_measurement];
+  int<lower=1,upper=N_enzyme> enzyme_yenz[N_enzyme_measurement];
+  vector[N_enzyme_measurement] yenz;
+  vector<lower=0>[N_enzyme_measurement] sigma_enz;
+  // hardcoded priors
+  vector[N_metabolite] prior_loc_formation_energy;
+  vector<lower=0>[N_metabolite] prior_scale_formation_energy;
+  vector[N_kinetic_parameters] prior_loc_kinetic_parameters;
+  vector<lower=0>[N_kinetic_parameters] prior_scale_kinetic_parameters;
+  real prior_loc_conc[N_experiment, N_mic];
+  real<lower=0> prior_scale_conc[N_experiment, N_mic];
+  real prior_loc_enzyme[N_experiment, N_enzyme];
+  real<lower=0> prior_scale_enzyme[N_experiment, N_enzyme];
+  // network properties
+  matrix[N_mic, N_enzyme] stoichiometric_matrix;
+  int<lower=1,upper=N_metabolite> metabolite_ix_stoichiometric_matrix[N_mic];
+}
+transformed data {
+  real xr[0];
+  int xi[0];
+  real minus_RT = - 0.008314 * 298.15;
+
+}
+parameters {
+  vector[N_metabolite] formation_energy;
+  vector<lower=0>[N_kinetic_parameters] kinetic_parameters;
+  vector<lower=0>[N_enzyme] enzyme_concentration[N_experiment];
+  vector<lower=0>[N_mic] conc[N_experiment];
+}
+transformed parameters {
+  real initial_time = 0;
+  vector[N_reaction] flux[N_experiment];
+  vector[N_enzyme] delta_g = stoichiometric_matrix' * formation_energy[metabolite_ix_stoichiometric_matrix];
+  for (e in 1:N_experiment){ 
+    vector[N_enzyme] keq = exp(delta_g / minus_RT);
+    vector[N_unbalanced+N_enzyme+N_enzyme+N_kinetic_parameters] theta = append_row(append_row(append_row(
+      conc[e, unbalanced_mic_ix], enzyme_concentration[e]), keq), kinetic_parameters);
+    flux[e] = get_fluxes(to_array_1d(conc[e, balanced_mic_ix]), to_array_1d(theta));
+  }
+}
+model {
+  kinetic_parameters ~ lognormal(log(prior_loc_kinetic_parameters), prior_scale_kinetic_parameters);
+  formation_energy ~ normal(prior_loc_formation_energy, prior_scale_formation_energy);
+  for (e in 1:N_experiment){
+    conc[e, ] ~ lognormal(log(prior_loc_conc[e]), prior_scale_conc[e]);
+    enzyme_concentration[e] ~ lognormal(log(prior_loc_enzyme[e]), prior_scale_enzyme[e]);
+  }
+  for (c in 1:N_conc_measurement){
+    target += lognormal_lpdf(yconc[c] | log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
+  }
+  for (ec in 1:N_enzyme_measurement){
+    target += lognormal_lpdf(yenz[ec] | log(enzyme_concentration[experiment_yenz[ec], enzyme_yenz[ec]]), sigma_enz[ec]);
+  }
+}
+generated quantities {
+  vector[N_conc_measurement] yconc_sim;
+  vector[N_enzyme_measurement] yenz_sim;
+  vector[N_flux_measurement] yflux_sim;
+
+
+  for (c in 1:N_conc_measurement){
+    yconc_sim[c] = lognormal_rng(log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
+  }
+  for (ec in 1:N_enzyme_measurement){
+    yenz_sim[ec] = lognormal_rng(log(enzyme_concentration[experiment_yenz[ec], enzyme_yenz[ec]]), sigma_enz[ec]);
+  }
+  for (f in 1:N_flux_measurement){
+    yflux_sim[f] = normal_rng(flux[experiment_yflux[f], reaction_yflux[f]], sigma_flux[f]);
+  }
+}


### PR DESCRIPTION
# Summary
There's no current way of checking prior/measurement specifications without running a full sampling method. This treats all enzymes independently and samples from their prior and measured concentrations for each metabolite, enzyme, kinetic parameter, and formation energy. The purpose is to check if the measured fluxes can be achieved without conditioning on them.

## Commits
* Feat: prior sampling of enzyme fluxes
* Test: fixing tox errors
* Test: continuation of tox error fixing
* Test: fixing formatting issues
* Feat: including confirmation of appropriate prior spec

# Use
This is how the command line interface is set up to use this feature:
`maud prior [data_input_path] [options]`
The output will be printed in the command line telling you which experiment and flux were measured outside of their sampled fluxes. This could indicate many things such as poor parameter specification, poor enzyme measurement concentration, or both. I've also included the sample printout to give you an indication on the spread and if the samples are converging.