### PR TITLE
Parallelise likelihood with reduce_sum

### DIFF
--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -97,6 +97,7 @@ pass
     help="How long the ODE simulates for (Units are whatever your time units are)",
 )
 @click.option("--output_dir", default=".", help="Where to save Maud's output")
+@click.option("--threads_per_chain", default=1, help="How many threads per chain")
 @click.argument(
     "data_path",
     type=click.Path(exists=True, dir_okay=False),

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -136,7 +136,9 @@ def sample(
                 os.remove(p)
     include_path = os.path.join(here, INCLUDE_PATH)
     model = cmdstanpy.CmdStanModel(
-        stan_file=stan_program_filepath, stanc_options={"include_paths": [include_path]}
+        stan_file=stan_program_filepath, 
+        stanc_options={"include_paths": [include_path]},
+        cpp_options = {"STAN_THREADS": True}
     )
     return model.sample(
         data=input_filepath,

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -90,6 +90,7 @@ def sample(
     n_cores: int,
     timepoint: float,
     output_dir: str,
+    threads_per_chain: int,
 ) -> cmdstanpy.CmdStanMCMC:
     """Sample from a posterior distribution.
 
@@ -106,7 +107,10 @@ def sample(
     :param time_step: Amount of time for the ode solver to simulate in order to compare
     initial state with evolved state
     :param: output_dir: Directory to save output
+    :param: threads_per_chain: Number of threads per chain (default is 1)
     """
+    if threads_per_chain != 1:
+        os.environ["STAN_NUM_THREADS"] = str(threads_per_chain)
     model_name = os.path.splitext(os.path.basename(data_path))[0]
     input_filepath = os.path.join(output_dir, f"input_data_{model_name}.json")
 
@@ -135,10 +139,11 @@ def sample(
             if os.path.exists(p):
                 os.remove(p)
     include_path = os.path.join(here, INCLUDE_PATH)
+    cpp_options = {"STAN_THREADS": True} if threads_per_chain != 1 else None
     model = cmdstanpy.CmdStanModel(
-        stan_file=stan_program_filepath, 
+        stan_file=stan_program_filepath,
         stanc_options={"include_paths": [include_path]},
-        cpp_options = {"STAN_THREADS": True}
+        cpp_options=cpp_options,
     )
     return model.sample(
         data=input_filepath,

--- a/src/maud/stan_code/functions_block.stan
+++ b/src/maud/stan_code/functions_block.stan
@@ -1,5 +1,6 @@
 functions{
 #include big_k_rate_equations.stan
+#include partial_sums.stan
 #include haldane_relationships.stan
 #include allostery.stan
   {{fluxes_function}}

--- a/src/maud/stan_code/inference_model_lower_blocks.stan
+++ b/src/maud/stan_code/inference_model_lower_blocks.stan
@@ -15,15 +15,15 @@ data {
   int<lower=1,upper=N_mic> balanced_mic_ix[N_mic-N_unbalanced];
   int<lower=1,upper=N_experiment> experiment_yconc[N_conc_measurement];
   int<lower=1,upper=N_mic> mic_ix_yconc[N_conc_measurement];
-  vector[N_conc_measurement] yconc;
+  real yconc[N_conc_measurement];
   vector<lower=0>[N_conc_measurement] sigma_conc;
   int<lower=1,upper=N_experiment> experiment_yflux[N_flux_measurement];
   int<lower=1,upper=N_reaction> reaction_yflux[N_flux_measurement];
-  vector[N_flux_measurement] yflux;
+  real yflux[N_flux_measurement];
   vector<lower=0>[N_flux_measurement] sigma_flux;
   int<lower=1,upper=N_experiment> experiment_yenz[N_enzyme_measurement];
   int<lower=1,upper=N_enzyme> enzyme_yenz[N_enzyme_measurement];
-  vector[N_enzyme_measurement] yenz;
+  real yenz[N_enzyme_measurement];
   vector<lower=0>[N_enzyme_measurement] sigma_enz;
   // hardcoded priors
   vector[N_metabolite] prior_loc_formation_energy;
@@ -90,15 +90,12 @@ model {
     enzyme_concentration[e] ~ lognormal(log(prior_loc_enzyme[e]), prior_scale_enzyme[e]);
   }
   if (LIKELIHOOD == 1){
-    for (c in 1:N_conc_measurement){
-      target += lognormal_lpdf(yconc[c] | log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
-    }
-    for (ec in 1:N_enzyme_measurement){
-      target += lognormal_lpdf(yenz[ec] | log(enzyme_concentration[experiment_yenz[ec], enzyme_yenz[ec]]), sigma_enz[ec]);
-    }
-    for (f in 1:N_flux_measurement){
-      target += normal_lpdf(yflux[f] | flux[experiment_yflux[f], reaction_yflux[f]], sigma_flux[f]);
-    }
+    target += reduce_sum(partial_sum_conc, yconc, 1,
+                         conc, experiment_yconc, mic_ix_yconc, sigma_conc);
+    target += reduce_sum(partial_sum_enz, yenz, 1,
+                         enzyme_concentration, experiment_yenz, enzyme_yenz, sigma_enz);
+    target += reduce_sum(partial_sum_flux, yflux, 1,
+                         flux, experiment_yflux, reaction_yflux, sigma_flux);
   }
 }
 generated quantities {

--- a/src/maud/stan_code/partial_sums.stan
+++ b/src/maud/stan_code/partial_sums.stan
@@ -1,4 +1,4 @@
-real partial_sum_conc(real[] y,
+real partial_sum_conc(real[] y_slice,
                       int start,
                       int end,
                       vector[] conc,
@@ -7,11 +7,11 @@ real partial_sum_conc(real[] y,
                       vector sigma){
   real out = 0;
   for (c in start:end){
-    out += lognormal_lpdf(y[c] | log(conc[experiment[c], mic[c]]), sigma[c]);
+    out += lognormal_lpdf(y_slice[c-start+1] | log(conc[experiment[c], mic[c]]), sigma[c]);
   }
   return out;
 }
-real partial_sum_enz(real[] y,
+real partial_sum_enz(real[] y_slice,
                      int start,
                      int end,
                      matrix enz_conc,
@@ -20,11 +20,11 @@ real partial_sum_enz(real[] y,
                      vector sigma){
   real out = 0;
   for (c in start:end){
-    out += lognormal_lpdf(y[c] | log(enz_conc[experiment[c], enzyme[c]]), sigma[c]);
+    out += lognormal_lpdf(y_slice[c-start+1] | log(enz_conc[experiment[c], enzyme[c]]), sigma[c]);
   }
   return out;
 }
-real partial_sum_flux(real[] y,
+real partial_sum_flux(real[] y_slice,
                       int start,
                       int end,
                       matrix flux,
@@ -33,7 +33,7 @@ real partial_sum_flux(real[] y,
                       vector sigma){
   real out = 0;
   for (c in start:end){
-    out += normal_lpdf(y[c] | flux[experiment[c], reaction[c]], sigma[c]);
+    out += normal_lpdf(y_slice[c-start+1] | flux[experiment[c], reaction[c]], sigma[c]);
   }
   return out;
 }

--- a/src/maud/stan_code/partial_sums.stan
+++ b/src/maud/stan_code/partial_sums.stan
@@ -1,0 +1,39 @@
+real partial_sum_conc(real[] y,
+                      int start,
+                      int end,
+                      vector[] conc,
+                      int[] experiment,
+                      int[] mic,
+                      vector sigma){
+  real out = 0;
+  for (c in start:end){
+    out += lognormal_lpdf(y[c] | log(conc[experiment[c], mic[c]]), sigma[c]);
+  }
+  return out;
+}
+real partial_sum_enz(real[] y,
+                     int start,
+                     int end,
+                     matrix enz_conc,
+                     int[] experiment,
+                     int[] enzyme,
+                     vector sigma){
+  real out = 0;
+  for (c in start:end){
+    out += lognormal_lpdf(y[c] | log(enz_conc[experiment[c], enzyme[c]]), sigma[c]);
+  }
+  return out;
+}
+real partial_sum_flux(real[] y,
+                      int start,
+                      int end,
+                      matrix flux,
+                      int[] experiment,
+                      int[] reaction,
+                      vector sigma){
+  real out = 0;
+  for (c in start:end){
+    out += normal_lpdf(y[c] | flux[experiment[c], reaction[c]], sigma[c]);
+  }
+  return out;
+}

--- a/tests/test_integration/test_pipeline.py
+++ b/tests/test_integration/test_pipeline.py
@@ -41,6 +41,7 @@ def test_linear():
         "timepoint": 500,
         "output_dir": temp_directory,
         "data_path": linear_input,
+        "threads_per_chain": 1,
     }
     fit = sampling.sample(**linear_input_values)
     samples_test = fit.get_drawset()


### PR DESCRIPTION
Uses Stan's new `reduce_sum` function to parallelise the likelihood if possible. 

This should hopefully speed the model up a bit but to verify this we'll need to try it out on a computer with lots of cores. 