### PR TITLE
Doc: document Maud's statistical model, add new helper functions

### DIFF
--- a/docs/theory/statistics.rst
+++ b/docs/theory/statistics.rst
@@ -1,10 +1,174 @@
 ==================
-Statistical issues
+Statistical Model
 ==================
 
-This document addresses statistical questions to do with Maud, such as:
+This document describes Maud from a statistical point of view.
 
- - How does Maud frame the task of learning from multi-omics data as a
-   statistical inference problem?
+Maud's statistical model separates the information that might be available
+about a metabolic network into three different kinds:
 
- - What are some statistical assumptions that Maud makes?
+- structural information implicit in a kinetic model
+- information contained in directly modelled experiments
+- information from other sources
+
+The role of the statistical model is to synthesise these different sources of
+information, making it possible to say exactly what is known about a metabolic
+network after a series of experiments.
+
+More specifically, the statistical model is a joint probability distribution
+:math:`\pi: \Theta \times Y\rightarrow [0,1]` that defines the probability
+density :math:`\pi(\theta, y)` of any possible combination of unknown
+parameters :math:`\theta` and observations :math:`y`. This model is written
+explicitly as a Stan program.
+
+Given a kinetic model and a set of observations :math:`y`, Maud uses Stan's
+adaptive Hamiltonian Monte Carlo algorithm to draw samples from the posterior
+distribution :math:`p(\theta\mid y)`. Each draw contains a configuration of
+unknown parameter values. Quantitative questions about the metabolic network
+can be answered by interrogating the ensemble of posterior draws.
+
+
+Structural Information
+=====================================================
+
+Maud assumes that the following structural information is known in advance:
+
+- The volume of each compartment and the metabolites it houses
+- The network stoichiometry, i.e. the proportions in which each reaction in the
+  network creates and destroys metabolites and which enzymes catalyse which
+  reactions. This information is encapsulated in a stoichiometric matrix
+  :math:`S` with a row for each metabolite-in-compartment and a column for each
+  enzyme.
+- Which metabolites-in-compartment modify which enzymes and how
+- Which metabolites-in-compartments are 'balanced', i.e. their concentrations
+  do not change when the system is in a steady state.
+
+We refer to this structural information collectively as a kinetic model. See
+[LINK] for a detailed description of these from a scientific point of view.
+
+The kinetic model defines a system of ODEs - one differential equation for each
+metabolite-in-compartment - with the rate of change of each
+metabolite-in-compartment :math:`m_i` described by the following equation:
+
+.. math::
+
+  \frac{dm_{i}}{dt} = \sum_{j} S_{ij} v_{j}(\theta, \mathbf{m})
+
+When the system is at a steady state, all the balanced
+metabolites-in-compartments have unchanging concentrations, so their entries in
+the equation above are zero.
+
+For a given set of parameters, enzyme concentrations and initial metabolite
+conditions, there should be a single steady state balanced metabolite
+concentration and set of fluxes.
+
+The kinetic model's role in Maud's statistical model is to connect latent
+parameters - i.e. :math:`\theta` above - with measureable quantities,
+i.e. :math:`\mathbf{m}` and :math:`\mathbf{v}`. 
+
+
+Experimental Information
+========================
+
+Maud represents information from experiments that measure enzyme concentrations
+and metabolite concentrations using the following regression model, where
+:math:`y` is the observation and :math:`\hat{y}` is the unobserved true value
+of the experimentally measured quantity:
+
+.. math::
+
+   y \sim LogNormal(\log(\hat{y}), \sigma)
+
+Measurements of reaction fluxes use the following similar regression model:
+
+.. math::
+
+   y \sim Normal(\hat{y}, \sigma)
+   
+
+In all three cases it is assumed that for each kind of measurement the error
+standard deviation :math:`\sigma` is known (though this number is in general
+different for each measured quantity in each experiment). It is the user's
+responsibility to choose values that reflect the accuracy of the measurement
+apparatus.
+
+The log-normal distribution was chosen to represent experimental metabolite and
+enzyme concentration measurements because the apparatuses used to measure these
+quantities typically have multiplicative errors. In other words, if the
+measured value is large, then the associated error is also proportionally
+large.
+
+
+Relative measurements
+---------------------
+
+In many realistic cases a measurement apparatus will give comparatively
+accurate information about the relative concentrations of some metabolites or
+enzymes while being comparatively uninformative as to their absolute
+values. While Maud currently does not support this kind of measurement, support
+is planned and will take the following form.
+
+
+Non-experimental Information
+============================
+
+Information that does not naturally take the form of an experimental
+measurement can be expressed in Maud's prior model. Maud allows users to
+specify independent log-normal priors for the following quantities:
+
+- enzyme :math:`kcat` parameters
+- enzyme/metabolite-in-compartment :math:`km` parameters
+- enzyme transfer constants
+- enzyme/metabolite-in-compartment inhibition and dissociation constants
+- enzyme concentrations
+- unbalanced metabolite concentrations
+
+For metabolite formation energies, which can be both negative and positive
+numbers, Maud allows users to specific independent normal priors.
+
+Users are encouraged to choose prior locations and scales using the method by
+calculating quantiles. Prior information is often easiest to ellicit in the
+form of qualitative statements like "it is very unlikely that :math:`kcat_e` is
+higher than 6.8 or lower than 0.4". Information in this form naturally
+translates into restrictions on the quantiles of the corresponding marginal
+prior distribution - for example that the prior mass for the events
+:math:`kcat_e > 6.8` and :math:`kcat_e < 0.4` should each be about 1%. The
+prior values can then be calculated as roughly :math:`\mu_{kcat_e} = 0.5003`
+and :math:`\sigma_{kcat_e} = 0.6089`.
+
+Maud includes convenience functions for working out priors in this way, which
+can be used in a python environment as follows:
+
+.. code::
+
+  In [1]: from maud.utils import get_lognormal_parameters_from_quantiles 
+
+  In [2]: get_lognormal_parameters_from_quantiles(0.4, 0.01, 6.8, 0.99)
+  Out[2]: (0.5003159401539531, 0.608940170915830)
+
+
+Information about fluxes and balanced metabolite concentrations
+----------------------------------------------------
+
+It is currently not possible to include non-experimental information about
+fluxes and steady-state concentrations of balanced metabolites.
+
+This is due to a technical limitatation. Since fluxes and steady state
+metabolite concentrations are calculated from the values of other parameters by
+finding the solution to the ODE system, directly setting priors would introduce
+a bias without a compensating Jacobian adjustment. We have not found a way to
+introduce this Jacobian adjustment, so Maud unfortunately cannot currently
+represent this information.
+
+
+Multivariate priors
+-------------------
+
+Sometimes the non-experimental information about two parameters is not
+independent. For example, some linear combinations of formation energies are
+known within a relatively small range even though the marginal value of each
+component of the linear combination is not well known.
+
+In such cases a multivariate distribution is required in order to express the
+available information. This functionality is not yet supported, but will be
+soon.

--- a/docs/theory/statistics.rst
+++ b/docs/theory/statistics.rst
@@ -98,6 +98,15 @@ quantities typically have multiplicative errors. In other words, if the
 measured value is large, then the associated error is also proportionally
 large.
 
+Summary statistics
+------------------
+
+It is common for experimental results to be reported in the form of a sample
+mean and standard deviation. It is important to note that for non-negative
+quantities like metabolite and enzyme concentrations these summary statistics
+will generally not be good values use as :math:`y` and :math:`\sigma` above. If
+possible, non-summarised measurement results should be used instead.
+
 
 Relative measurements
 ---------------------

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -33,6 +33,7 @@ SAMPLING_DEFAULTS = {
     "n_chains": 4,
     "n_cores": 4,
     "timepoint": 500,
+    "save_warmup": True,
 }
 RELATIVE_PATH_EXAMPLE = "../../tests/data/linear.toml"
 
@@ -97,6 +98,8 @@ pass
 )
 @click.option("--output_dir", default=".", help="Where to save Maud's output")
 @click.option("--threads_per_chain", default=1, help="How many threads per chain")
+@click.option("--save_warmup", default=SAMPLING_DEFAULTS["save_warmup"],
+              help="Whether to save warmup draws")
 @click.argument(
     "data_path",
     type=click.Path(exists=True, dir_okay=False),

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -98,8 +98,11 @@ pass
 )
 @click.option("--output_dir", default=".", help="Where to save Maud's output")
 @click.option("--threads_per_chain", default=1, help="How many threads per chain")
-@click.option("--save_warmup", default=SAMPLING_DEFAULTS["save_warmup"],
-              help="Whether to save warmup draws")
+@click.option(
+    "--save_warmup",
+    default=SAMPLING_DEFAULTS["save_warmup"],
+    help="Whether to save warmup draws",
+)
 @click.argument(
     "data_path",
     type=click.Path(exists=True, dir_okay=False),

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -100,6 +100,7 @@ def sample(
     timepoint: float,
     output_dir: str,
     threads_per_chain: int,
+    save_warmup: bool,
 ) -> cmdstanpy.CmdStanMCMC:
     """Sample from a posterior distribution.
 
@@ -117,6 +118,7 @@ def sample(
     initial state with evolved state
     :param: output_dir: Directory to save output
     :param: threads_per_chain: Number of threads per chain (default is 1)
+    :param: save_warmup: whether to save warmup draws (default is True)
     """
     if threads_per_chain != 1:
         os.environ["STAN_NUM_THREADS"] = str(threads_per_chain)
@@ -146,7 +148,7 @@ def sample(
         output_dir=output_dir,
         iter_warmup=n_warmup,
         max_treedepth=15,
-        save_warmup=True,
+        save_warmup=save_warmup,
         inits=init_filepath,
         show_progress=True,
     )

--- a/src/maud/utils.py
+++ b/src/maud/utils.py
@@ -18,6 +18,9 @@
 
 from typing import Dict, Iterable
 
+import numpy as np
+from scipy.stats import norm
+
 from maud.data_model import KineticModel
 
 
@@ -46,3 +49,31 @@ def get_enzyme_codes(kinetic_model: KineticModel) -> Dict[str, int]:
         for enz_id, _ in rxn.enzymes.items():
             enzyme_ids.append(enz_id)
     return codify(enzyme_ids)
+
+
+def get_lognormal_parameters_from_quantiles(x1, p1, x2, p2):
+    """Find parameters for a lognormal distribution from two quantiles.
+
+    i.e. get mu and sigma such that if X ~ lognormal(mu, sigma), then pr(X <
+    x1) = p1 and pr(X < x2) = p2.
+
+    """
+    logx1 = np.log(x1)
+    logx2 = np.log(x2)
+    denom = norm.ppf(p2) - norm.ppf(p1)
+    sigma = (logx2 - logx1) / denom
+    mu = (logx1 * norm.ppf(p2) - logx2 * norm.ppf(p1)) / denom
+    return mu, sigma
+
+
+def get_normal_parameters_from_quantiles(x1, p1, x2, p2):
+    """Find parameters for a normal distribution from two quantiles.
+
+    i.e. get mu and sigma such that if X ~ normal(mu, sigma), then pr(X <
+    x1) = p1 and pr(X < x2) = p2.
+
+    """
+    denom = norm.ppf(p2) - norm.ppf(p1)
+    sigma = (x2 - x1) / denom
+    mu = (x1 * norm.ppf(p2) - x2 * norm.ppf(p1)) / denom
+    return mu, sigma

--- a/tests/test_integration/test_pipeline.py
+++ b/tests/test_integration/test_pipeline.py
@@ -38,9 +38,10 @@ def test_linear():
         "output_dir": temp_directory,
         "data_path": linear_input,
         "threads_per_chain": 1,
+        "save_warmup": False,
     }
     fit = sampling.sample(**linear_input_values)
-    samples_test = fit.get_drawset()
+    samples_test = fit.draws_as_dataframe()
     samples_ctrl = pd.read_csv(linear_control_file, comment="#").iloc[200:]
     # Check that the output and the control have the same column names.
     assert all(samples_test.columns == samples_ctrl.columns)

--- a/tests/test_unit/test_utils.py
+++ b/tests/test_unit/test_utils.py
@@ -1,0 +1,30 @@
+"""Test functions from the utils module."""
+
+
+import numpy as np
+
+import maud.utils as utils
+
+
+def test_get_lognormal_parameters_from_quantiles():
+    """Test that the function get_lognormal_parameters_from_quantiles works."""
+    inputs = [
+        (0.4, 0.01, 6.8, 0.99),
+    ]
+    expected = [
+        (0.5003159401539531, 0.608940170915830),
+    ]
+    for args, (expected_mu, expected_sigma) in zip(inputs, expected):
+        mu, sigma = utils.get_lognormal_parameters_from_quantiles(*args)
+        assert np.isclose(mu, expected_mu)
+        assert np.isclose(sigma, expected_sigma)
+
+
+def test_get_normal_parameters_from_quantiles():
+    """Test that the function get_normal_parameters_from_quantiles works."""
+    inputs = [(-3, 0.1, 2, 0.6)]
+    expected = [(1.174710655806321, 3.2575440333782133)]
+    for args, (expected_mu, expected_sigma) in zip(inputs, expected):
+        mu, sigma = utils.get_normal_parameters_from_quantiles(*args)
+        assert np.isclose(mu, expected_mu)
+        assert np.isclose(sigma, expected_sigma)


### PR DESCRIPTION
This change explains what statistical model Maud is trying to implement as part of #228. 

To review you probably want to build the docs locally by running `make html` from the `docs` folder, then open the file `docs/_build/html/index.html` with a web browswer. If you haven't already done so you'll need to run `pip install -e .[development]` to install all the dependencies required to build the documentation.

When I got to the bit about how priors should be set I realised that the recommended method of setting the prior location and scale parameters based on quantiles is a bit hard to implement, so I bundled in some helper functions that make it easier.