### PR TITLE
Robust test

### DIFF
--- a/tests/test_integration/test_pipeline.py
+++ b/tests/test_integration/test_pipeline.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import tempfile
+
 import pandas as pd
 
 import maud.sampling as sampling
@@ -116,8 +117,8 @@ def test_linear():
         "rel_tol": 1e-6,
         "max_num_steps": int(1e9),
         "likelihood": 1,
-        "n_samples": 2,
-        "n_warmup": 2,
+        "n_samples": 200,
+        "n_warmup": 200,
         "n_chains": 1,
         "n_cores": 1,
         "timepoint": 500,

--- a/tests/test_integration/test_pipeline.py
+++ b/tests/test_integration/test_pipeline.py
@@ -128,14 +128,16 @@ def test_linear():
     }
     fit = sampling.sample(**linear_input_values)
     samples_test = fit.draws_pd()
-    expected_df = pd.DataFrame.from_dict(expected, orient="index", columns = ["5% CI", "95% CI"])
-    samples_test.loc['mean', :] = samples_test.mean()
-    sample_mean = samples_test.loc['mean'].transpose()
+    expected_df = pd.DataFrame.from_dict(
+        expected, orient="index", columns=["5% CI", "95% CI"]
+    )
+    samples_test.loc["mean", :] = samples_test.mean()
+    sample_mean = samples_test.loc["mean"].transpose()
     validation_df = expected_df.join(sample_mean)
     # Check that each output column (other than the diagnostic ones) is
     # statistically similar to its matching control column.
     test_mean = samples_test.mean()
-    remove_indicies = [idx for idx in validation_df.index if idx.endswith("__")] + ["lp__"]
+    remove_indicies = [idx for idx in validation_df.index if idx.endswith("__")]
     validation_df.drop(remove_indicies, inplace=True)
     for index, row in validation_df.iterrows():
         assert row["mean"] >= row["5% CI"], index + " is too low."

--- a/tests/test_integration/test_pipeline.py
+++ b/tests/test_integration/test_pipeline.py
@@ -137,7 +137,6 @@ def test_linear():
     validation_df = expected_df.join(sample_mean)
     # Check that each output column (other than the diagnostic ones) is
     # statistically similar to its matching control column.
-    test_mean = samples_test.mean()
     remove_indicies = [idx for idx in validation_df.index if idx.endswith("__")]
     validation_df.drop(remove_indicies, inplace=True)
     for index, row in validation_df.iterrows():

--- a/tests/test_integration/test_pipeline.py
+++ b/tests/test_integration/test_pipeline.py
@@ -132,6 +132,7 @@ def test_linear():
     test_mean = samples_test.mean()
     cols = [c for c in expected.keys() if not c.endswith("__")]
     for col in cols:
+        assert col in samples_test.columns, col + " is not present in test"
         assert test_mean[col] >= expected[col][0], col + " is too low."
         assert test_mean[col] <= expected[col][1], col + " is too high."
     # Delete temporary directory


### PR DESCRIPTION
# Summary
The pipeline test runs through all of the Maud workflow from input to sampling. An issue previously encountered was the compatibility with cmdstanpy and/or arviz, which like to change their functions a lot. This PR removes a lot of the reliance using a dictionary to specify the 90% CI, and converting the fit object to a dataframe. There is no reliance on Arviz and the test should now be robust to additional parameters introduced into the Stan program. For example:
* Transformed Gibbs Energies,
* Transformed Kinetic Parameters,
* Enzyme specific fluxes.

# Commit History
* test: using dataframes to compare test results
* style: satisfying black style guide
* bug: resetting warmup and sampling iterations
* style: removing unnecessary code