### PR TITLE
Rescale params

### DIFF
--- a/src/maud/inference_model.stan
+++ b/src/maud/inference_model.stan
@@ -111,7 +111,7 @@ transformed parameters {
   vector[N_allosteric_inhibitor] dissociation_constant_t =
     exp(log(prior_loc_diss_t) + log_dissociation_constant_t_z .* prior_scale_diss_t);
   vector[N_allosteric_activator] dissociation_constant_r =
-    exp(log(prior_loc_diss_t) + log_dissociation_constant_r_z .* prior_scale_diss_r);
+    exp(log(prior_loc_diss_r) + log_dissociation_constant_r_z .* prior_scale_diss_r);
   vector[N_allosteric_enzyme] transfer_constant =
     exp(log(prior_loc_tc) + log_transfer_constant_z .* prior_scale_tc);
   matrix[N_experiment, N_drain] drain;

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -217,15 +217,16 @@ def get_experiment(raw: Dict) -> Experiment:
     out = Experiment(id=raw["id"])
     for target_type in ["metabolite", "reaction", "enzyme"]:
         type_measurements = {}
-        for m in raw[target_type + "_measurements"]:
-            measurement = Measurement(
-                target_id=m["target_id"],
-                value=m["value"],
-                uncertainty=m["uncertainty"],
-                scale="ln",
-                target_type=target_type,
-            )
-            type_measurements.update({m["target_id"]: measurement})
+        if target_type + "_measurements" in raw.keys():
+            for m in raw[target_type + "_measurements"]:
+                measurement = Measurement(
+                    target_id=m["target_id"],
+                    value=m["value"],
+                    uncertainty=m["uncertainty"],
+                    scale="ln",
+                    target_type=target_type,
+                )
+                type_measurements.update({m["target_id"]: measurement})
         out.measurements.update({target_type: type_measurements})
     if "knockouts" in raw.keys():
         out.knockouts = raw["knockouts"]

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -177,7 +177,7 @@ def sample(
         iter_warmup=n_warmup,
         max_treedepth=11,
         save_warmup=save_warmup,
-        inits=init_filepath,
+        inits=0,
         show_progress=True,
         step_size=0.025,
         adapt_delta=0.99,

--- a/tests/data/ecoli_small.toml
+++ b/tests/data/ecoli_small.toml
@@ -116,7 +116,7 @@ enzyme_concentrations = [
   {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='FBP', location=0.00592291, scale=0.047},
   {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='FBA', location=0.0702922488972023, scale=0.19},
   {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='TPI', location=0.020866941, scale=0.13},
-  {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='PFK', location=0.018055101, scale=0.13}
+  {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='PFK', location=0.018055101, scale=0.13},
   {experiment_id="Evo04Evo01EP", enzyme_id='PGI', location=0.033875912, scale=0.06},
   {experiment_id="Evo04Evo01EP", enzyme_id='FBP', location=0.00592291, scale=0.047},
   {experiment_id="Evo04Evo01EP", enzyme_id='FBA', location=0.0702922488972023, scale=0.19},

--- a/tests/data/ecoli_small.toml
+++ b/tests/data/ecoli_small.toml
@@ -111,16 +111,35 @@ kms = [
   # {enzyme_id = "PGK", mic_id = "13dpg_c", location = 2.02, scale = 1.5},
   # {enzyme_id = "PGK", mic_id = "adp_c", location = 0.6, scale = 1.5}
 ]
+enzyme_concentrations = [
+  {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='PGI', location=0.033875912, scale=0.06},
+  {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='FBP', location=0.00592291, scale=0.047},
+  {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='FBA', location=0.0702922488972023, scale=0.19},
+  {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='TPI', location=0.020866941, scale=0.13},
+  {experiment_id="Evo04ptsHIcrrEvo01EP", enzyme_id='PFK', location=0.018055101, scale=0.13}
+  {experiment_id="Evo04Evo01EP", enzyme_id='PGI', location=0.033875912, scale=0.06},
+  {experiment_id="Evo04Evo01EP", enzyme_id='FBP', location=0.00592291, scale=0.047},
+  {experiment_id="Evo04Evo01EP", enzyme_id='FBA', location=0.0702922488972023, scale=0.19},
+  {experiment_id="Evo04Evo01EP", enzyme_id='TPI', location=0.0198, scale=0.1},
+  {experiment_id="Evo04Evo01EP", enzyme_id='PFK', location=0.0185, scale=0.05}
+]
+unbalanced_metabolites = [
+  {experiment_id="Evo04ptsHIcrrEvo01EP", mic_id='g6p_c', location=2.0804108, scale=0.188651},
+  {experiment_id="Evo04ptsHIcrrEvo01EP", mic_id='adp_c', location=0.6113649, scale=0.038811},
+  {experiment_id="Evo04ptsHIcrrEvo01EP", mic_id='atp_c', location=5.4080032, scale=0.186962},
+
+  {experiment_id="Evo04Evo01EP", mic_id='g6p_c', location=2.0804108, scale=0.188651},
+  {experiment_id="Evo04Evo01EP", mic_id='adp_c', location=0.6113649, scale=0.038811},
+  {experiment_id="Evo04Evo01EP", mic_id='atp_c', location=5.4080032, scale=0.186962},
+]
+
 
 ################## Experimental data #################
 
 [[experiments]]
 id = 'Evo04ptsHIcrrEvo01EP'
 metabolite_measurements = [
-  {target_id='g6p_c', value=2.0804108, uncertainty=0.188651},
   {target_id='f6p_c', value=0.6410029, uncertainty=0.146145},
-  {target_id='adp_c', value=0.6113649, uncertainty=0.038811},
-  {target_id='atp_c', value=5.4080032, uncertainty=0.186962},
   # {target_id='pi_c', value=2.0, uncertainty=0.2},  # made up
   {target_id='fdp_c', value=4.5428601, uncertainty=0.237197},
   {target_id='dhap_c', value=1.895018, uncertainty=0.078636},
@@ -131,31 +150,14 @@ metabolite_measurements = [
 reaction_measurements = [
   {target_id='PGI', value=4.087673533555556, uncertainty=0.1},
 ]
-enzyme_measurements = [
-  {target_id='PGI', value=0.033875912, uncertainty=0.06},
-  {target_id='FBP', value=0.00592291, uncertainty=0.047},
-  {target_id='FBA', value=0.0702922488972023, uncertainty=0.19},
-  {target_id='TPI', value=0.020866941, uncertainty=0.13},
-  {target_id='PFK', value=0.018055101, uncertainty=0.13}
-]
 
 [[experiments]]
 id = 'Evo04Evo01EP'
 metabolite_measurements = [
-  {target_id='g6p_c', value=2.0804108, uncertainty=0.188651},
   {target_id='f6p_c', value=0.6410029, uncertainty=0.146145},
-  {target_id='adp_c', value=0.6113649, uncertainty=0.038811},
-  {target_id='atp_c', value=5.4080032, uncertainty=0.186962},
   {target_id='fdp_c', value=4.5428601, uncertainty=0.237197},
   {target_id='dhap_c', value=1.895018, uncertainty=0.078636},
 ]
 reaction_measurements = [
   {target_id='PGI', value=4.087673533555556, uncertainty=0.1},
-]
-enzyme_measurements = [
-  {target_id='PGI', value=0.033875912, uncertainty=0.06},
-  {target_id='FBP', value=0.00592291, uncertainty=0.047},
-  {target_id='FBA', value=0.0702922488972023, uncertainty=0.19},
-  {target_id='TPI', value=0.0198, uncertainty=0.1},
-  {target_id='PFK', value=0.0185, uncertainty=0.05}
 ]


### PR DESCRIPTION
This change alters the Stan model so that all the non-transformed parameters are auxiliaries with standard normal distributions, with the meaningful parameters derived from these by shifting and scaling according to the priors.

There are two main reasons for doing this:
1) Performance. Stan generally prefers to work with numbers around unit scale. This should make life a little easier for the adaptation algorithm, as the correlations and differences in scale between the auxiliary parameters should be simpler and more consistent than between the meaningful ones.
2) Interpretability. A lot of the work with Maud going forward will involve trying to understand why the sampler behaves as it does, so as to improve performance by reparameterisation. It should be easier to inspect the auxiliary parameters for performance-relevant patterns than the meaningful parameters. For example, if a banana and horseshoe shaped posterior is slowing down the sampler, this should be apparent from a pairs plot of the auxiliaries, but could be hard to spot in the meaningful parameters.

To see how this affects the performance in practice I'm going to compare how long the simulation study script takes with this branch vs master on the workstation.