### PR TITLE
Bug: change size to rows for vectors in Stan code

### DIFF
--- a/src/maud/modular_rate_law.stan
+++ b/src/maud/modular_rate_law.stan
@@ -6,7 +6,7 @@ real get_Tr(vector metabolite,
   real plus_product = 1;
   real minus_product = 1;
   real k_minus = (kcat / keq);
-  for (m in 1:size(metabolite)){
+  for (m in 1:rows(metabolite)){
     real multiplicand = (metabolite[m] / km[m]) ^ abs(stoichiometry[m]);
     k_minus *= km[m] ^ stoichiometry[m];
     if (stoichiometry[m] < 0)
@@ -20,7 +20,7 @@ real get_Tr(vector metabolite,
 real get_Dr_common_rate_law(vector metabolite, vector km, vector stoichiometry){
   real psi_plus = 1;
   real psi_minus = 1;
-  for (m in 1:size(metabolite)){
+  for (m in 1:rows(metabolite)){
     real multiplicand = (1 + metabolite[m] / km[m]) ^ abs(stoichiometry[m]);
     if (stoichiometry[m] < 0)
       psi_plus *= multiplicand;


### PR DESCRIPTION
This caused an error for @areti1906: Stan's `size` function doesn't work on vectors. This change switches to the `rows` function, which does work for vectors.

Mysteriously I don't seem to get the same problem, but I guess who cares once it's fixed!