### PR TITLE
Feat: makefile command for removing auxiliary Stan files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ qa:
 	isort --recursive src/maud tests/ scripts/ setup.py
 	black src/maud tests/ scripts/ setup.py
 
+STAN_BINARY = src/maud/inference_model
+
+clean-stan:
+	$(RM) $(STAN_BINARY) $(STAN_BINARY).hpp $(STAN_BINARY).o
+
 ################################################################################
 # Self Documenting Commands                                                    #
 ################################################################################


### PR DESCRIPTION
Adds a new makefile command `clean-stan` which removes the binary, `.hpp` and `.o` files if they are present. This is just for convenience when a developer wants to recompile the main model.