### PR TITLE
Migrate to GitHub actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,8 @@ jobs:
     - name: Install Maud
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[`development`]
+        pwd
+        pip install .[development]
     - name: Install cmdstan
       run: install_cmdstan
     - name: Test with pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,26 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install Maud
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[`development`]
+    - name: Install cmdstan
+      run: install_cmdstan
+    - name: Test with pytest
+      run: tox

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,7 +1,6 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# This workflow installs Maud on Ubuntu with Python 3.7 and then runs tox
 
-name: Python application
+name: Run Maud tests
 
 on: push
 
@@ -19,9 +18,8 @@ jobs:
     - name: Install Maud
       run: |
         python -m pip install --upgrade pip
-        pwd
         pip install .[development]
     - name: Install cmdstan
       run: install_cmdstan
-    - name: Test with pytest
+    - name: Run tox
       run: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: python
-python: ["3.7"]
-sudo: false
-install: ["pip install -e .[development] && install_cmdstan"]
-script: ["tox"]


### PR DESCRIPTION
Our plan on Travis CI apparently has a limited number of computer minutes, which we [just passed](https://travis-ci.com/organizations/biosustain/plan/usage). This change switches us to github actions for CI, which avoids the problem.