### PR TITLE
Streamline automatic testing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+
+Checklist:
+
+- [ ] Updated any relevant documentation
+- [ ] Add an adr doc if appropriate
+- [ ] Include links to any relevant issues in the description
+- [ ] Unit tests passing
+- [ ] Integration tests passing

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -1,0 +1,26 @@
+# This workflow installs Maud on Ubuntu with Python 3.7 and then runs integration tests
+
+name: Run Maud integration tests
+
+on: workflow_dispatch
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install Maud
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[development]
+    - name: Install cmdstan
+      run: install_cmdstan
+    - name: Run integration tests
+      run: pytest tests/test_integration
+

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -1,6 +1,6 @@
 # This workflow installs Maud on Ubuntu with Python 3.7 and then runs tox
 
-name: Run Maud tests
+name: Install Maud and run tox
 
 on: push
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     pytest-cov
     pytest-raises
 commands =
-    pytest --cov=maud --cov-report=term {posargs}
+    pytest --cov=maud --cov-report=term --ignore=tests/test_integration {posargs}
 
 [testenv:py37]
 passenv =


### PR DESCRIPTION
A few commits aimed at improving the process with automatic tests. 

At the moment running `tox` triggers our integration tests, which take quite a long time to run. We should definitely run the integration tests before merging a pr, but it's annoying to spend ages waiting for them to run after every single push. 

This change makes `tox` only run the unit tests. Integration tests can be run locally with `pytest tests/test_integration` or with github actions using a new manual workflow. I've also added the following checklist to make sure we don't forget to run the new workflow:

Checklist:

- [x] Updated any relevant documentation
- [x] Add an adr doc if appropriate
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [ ] Integration tests passing
