### PR TITLE
Windows installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,14 +43,23 @@ environment from the latest master branch, run this command:
 
     pip install https://github.com/biosustain/Maud/archive/master.zip
 
-Cmdstanpy depends on `cmdstan <https://github.com/stan-dev/cmdstan>`_, which
-needs to be installed too. Fortunately, cmdstanpy comes with a command line
-script that installs cmdstan, so this step is pretty simple:
+Cmdstanpy depends on `cmdstan <https://github.com/stan-dev/cmdstan>`_, 
+which in turn requires a c++ toolchain. Fortunately, cmdstanpy comes with
+commands that can install these for you. On windows the necessary dependencies 
+can be installed with the following powershell commands:
+
+.. code-block:: console
+
+    python -m cmdstanpy.install_cxx_toolchain
+    python -m cmdstanpy.install_cmdstan --compiler
+
+On macos or Linux, you must install the c++ requirements manually 
+(see [here](https://cmdstanpy.readthedocs.io/en/v0.9.67/installation.html#install-cmdstan)) for instuctions. 
+Cmdstan can then be installed using this shell command:
 
 .. code-block:: console
 
     install_cmdstan
-
 
 Usage
 =====

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -23,9 +23,17 @@ environment from the latest master branch, run this command:
 
     pip install https://github.com/biosustain/Maud/archive/master.zip
 
-Cmdstanpy depends on `cmdstan <https://github.com/stan-dev/cmdstan>`_, which
-needs to be installed too. Fortunately, cmdstanpy comes with a command line
-script that installs cmdstan, so this step is pretty simple:
+Cmdstanpy depends on `cmdstan <https://github.com/stan-dev/cmdstan>`, which
+in turn requires a c++ toolchain. Fortunately, cmdstanpy comes with commands 
+that can install these for you. On windows the necessary dependencies can be 
+installed with the following powershell commands:
+
+python -m cmdstanpy.install_cxx_toolchain
+python -m cmdstanpy.install_cmdstan --compiler
+
+On macos or Linux, you must install the c++ requirements manually 
+(see [here](https://cmdstanpy.readthedocs.io/en/v0.9.67/installation.html#install-cmdstan))
+for instuctions. Cmdstan can then be installed using this shell command:
 
 .. code-block:: console
 


### PR DESCRIPTION
Updated the instructions for installing Maud on windows - this is what worked for Areti. 

If these instructions work for others, this should address issue #257.

Checklist:

- [x] Updated any relevant documentation
- [x] Add an adr doc if appropriate
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [x] Integration tests passing
