### PR TITLE
Validate flux specification

### DIFF
--- a/docs/adr/0015-validating-measured-fluxes.md
+++ b/docs/adr/0015-validating-measured-fluxes.md
@@ -1,0 +1,50 @@
+# 15. ensuring measured fluxes are unbiased
+
+Date: 2021-01-22
+
+## Status
+
+In Review
+
+## Context
+Defining the number of indenpendent fluxes isn't always clear.
+This is an issue as defining more fluxes than there are degrees
+of freedom when calculating the fluxes.
+
+An example would be this simplified network:
+
+	A -> B -> C
+
+where reaction 1 and reaction 2 are dependent, implying that
+no additional information is achieved by including both.
+
+Another issue is knowing when you do not have enough fluxes
+define, resulting in an underdetermined system. Due to the
+Bayesian implementation of Maud, resoliving these systems
+are still resolvable. However, supplimenting as much information
+as possible will likely be beneficial.
+
+## Decision
+Identifying underdetermined systems is acomplished by first calculating
+the null space of the matrix. This gives the number of degrees of freedom
+of the system as well. Then we calculate the reduced row echelon form of
+the transpose of the null space. The resulting matrix represents the
+independent flux pathways through the network as rows. If you take the
+measured subset of reactions and there is a row containing no non-zero
+entries then the system is not fully described using the current measurements.
+
+Determining if the system is overspecified is achieved by comparing the
+number of measurements to the degrees of freedom. If the number of measurements
+is larger than the degrees of freedom then the system is overdetermined.
+
+It is possible to both have an underdetermined system which is overspecified
+by having multiple measurements on dependent paths. It is also possible to
+recieve the warning that the system is overspecified by independent measurements.
+For instance, a linear pathway where the influx and efflux are both measured.
+This is still valid as they are independent measurements.
+
+## Consequences
+There are no direct consequences to the user, this effect Maud running in any
+way. The output of this feature may warn the user about possible biases present
+in the experiment definition. It is however completely up to the user to determine
+if these warnings apply to their notwork or not.

--- a/docs/adr/0016-validating-measured-fluxes.md
+++ b/docs/adr/0016-validating-measured-fluxes.md
@@ -1,4 +1,4 @@
-# 15. ensuring measured fluxes are unbiased
+# 16. checking that appropriate fluxes are measured
 
 Date: 2021-01-22
 
@@ -19,9 +19,9 @@ where reaction 1 and reaction 2 are dependent, implying that
 no additional information is achieved by including both.
 
 Another issue is knowing when you do not have enough fluxes
-define, resulting in an underdetermined system. Due to the
-Bayesian implementation of Maud, resoliving these systems
-are still resolvable. However, supplimenting as much information
+measured, resulting in an underdetermined system. Due to the
+Bayesian implementation of Maud, these systems are still theoretically
+resolvable. However, supplementing as much information
 as possible will likely be beneficial.
 
 ## Decision

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     arviz
     numpy
     scipy
+    sympy
     pandas
     matplotlib
     jinja2

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -17,6 +17,7 @@
 """Code for sampling from a posterior distribution."""
 
 import os
+import warnings
 from typing import Dict
 
 import cmdstanpy
@@ -111,15 +112,20 @@ def validate_specified_fluxes(
                 for rxn, st in flux_path.items():
                     if st != 0:
                         possible_measurements.append(rxn)
-                print("Your system appears to be underdetermined in experiment:")
-                print(f"{exp}")
-                print("Please define a reaction from the following list:")
-                print(f"{possible_measurements}")
+                msg = (
+                    f"Your system appears to be underdetermined in experiment:\n{exp}\n" +
+                    "Please define a reaction from the following list:\n"+
+                    f"{'\n'.join(possible_measurements)}"
+                )
+                warnings.warn(msg)
 
         if len(measured_rxn_list) > n_dof:
-            print("You appear to have specified too many reactions.")
-            print("This will bias the sampling as the measurements")
-            print("are not independent.")
+            msg = (
+                "You appear to have specified too many reactions.\n" +
+                "This will bias the statistical model\n"+
+                "as the measurements are not independent."
+            )
+            warnings.warn(msg)
 
 
 def get_knockout_matrix(mi: MaudInput):

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -26,7 +26,7 @@ import pandas as pd
 
 from maud import io
 from maud.data_model import KineticModel, MaudInput
-from maud.utils import null, rref
+from maud.utils import get_null_space, get_rref
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -84,7 +84,7 @@ def validate_specified_fluxes(
     drain_codes: Dict[str, int],
     balanced_mic_codes: Dict[str, int],
 ):
-    """Validate measured fluxes.
+    """Check that appropriate fluxes have been measured.
 
     :param S_complete: The stoichiometrix matrix including reactions and drains
     :param rxn_measurements: A dataframe containing all flux measurements
@@ -99,9 +99,9 @@ def validate_specified_fluxes(
             "target_id"
         ]
         measured_rxn_list = list(meas_rxns)
-        flux_paths = null(S_complete[balanced_mic_codes.keys()].T.values)
+        flux_paths = get_null_space(S_complete[balanced_mic_codes.keys()].T.values)
         n_rxns, n_dof = np.shape(flux_paths)
-        rref_flux_paths = np.matrix(rref(flux_paths.T))
+        rref_flux_paths = np.matrix(get_rref(flux_paths.T))
         rref_flux_paths[np.abs(rref_flux_paths) < 1e-10] = 0
         flux_paths_df = pd.DataFrame(rref_flux_paths, columns=complete_reactions)
         for _, flux_path in flux_paths_df.iterrows():

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -78,11 +78,20 @@ def get_full_stoichiometry(
 def validate_specified_fluxes(
     S_complete,
     rxn_measurements,
-    experiment_codes,
-    reaction_codes,
-    drain_codes,
-    balanced_mic_codes,
+    experiment_codes: Dict[str, int],
+    reaction_codes: Dict[str, int],
+    drain_codes: Dict[str, int],
+    balanced_mic_codes: Dict[str, int],
 ):
+    """Validate measured fluxes.
+
+    :param S_complete: The stoichiometrix matrix including reactions and drains
+    :param rxn_measurements: A dataframe containing all flux measurements
+    :param experiment_codes: the codified experiment codes
+    :param reaction_codes: the codified reaction codes
+    :param drain_codes: the codified drain codes
+    :param balanced_mic_codes: the codified balanced_mic codes
+    """
     complete_reactions = list(reaction_codes.keys()) + list(drain_codes.keys())
     for exp in experiment_codes:
         meas_rxns = rxn_measurements[rxn_measurements["experiment_id"] == exp][

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -75,15 +75,19 @@ def get_full_stoichiometry(
     return S_enz, S_enz_to_flux_map, S_complete, S_drain
 
 
-def validate_specified_fluxes(S_complete, 
-                              rxn_measurements,  
-                              experiment_codes, 
-                              reaction_codes, 
-                              drain_codes,
-                              balanced_mic_codes):
+def validate_specified_fluxes(
+    S_complete,
+    rxn_measurements,
+    experiment_codes,
+    reaction_codes,
+    drain_codes,
+    balanced_mic_codes,
+):
     complete_reactions = list(reaction_codes.keys()) + list(drain_codes.keys())
     for exp in experiment_codes:
-        meas_rxns = rxn_measurements[rxn_measurements["experiment_id"] == exp]["target_id"]
+        meas_rxns = rxn_measurements[rxn_measurements["experiment_id"] == exp][
+            "target_id"
+        ]
         measured_rxn_list = list(meas_rxns)
         flux_paths = null(S_complete[balanced_mic_codes.keys()].T.values)
         n_rxns, n_dof = np.shape(flux_paths)
@@ -411,12 +415,14 @@ def get_input_data(
         exp_id = prior_enz.experiment_id
         prior_loc_enzyme.loc[exp_id, enz_id] = prior_enz.location
         prior_scale_enzyme.loc[exp_id, enz_id] = prior_enz.scale
-    validate_specified_fluxes(full_stoic, 
-                              reaction_measurements,  
-                              experiment_codes, 
-                              reaction_codes, 
-                              drain_codes,
-                              balanced_mic_codes)
+    validate_specified_fluxes(
+        full_stoic,
+        reaction_measurements,
+        experiment_codes,
+        reaction_codes,
+        drain_codes,
+        balanced_mic_codes,
+    )
     return {
         "N_mic": len(mics),
         "N_unbalanced": len(unbalanced_mic_codes),

--- a/src/maud/utils.py
+++ b/src/maud/utils.py
@@ -57,10 +57,12 @@ def get_normal_parameters_from_quantiles(x1, p1, x2, p2):
 
 
 def null(a, rtol=1e-5):
+    """Calulate the null space of a matrix."""
     u, s, v = np.linalg.svd(a)
     rank = (s > rtol * s[0]).sum()
     return v[rank:].T.copy()
 
 
 def rref(mat):
+    """Return reduced row echelon form of a matrix."""
     return sp.Matrix(mat).rref(iszerofunc=lambda x: abs(x) < 1e-10)[0]

--- a/src/maud/utils.py
+++ b/src/maud/utils.py
@@ -19,6 +19,7 @@
 from typing import Dict, Iterable
 
 import numpy as np
+import sympy as sp
 from scipy.stats import norm
 
 
@@ -53,3 +54,12 @@ def get_normal_parameters_from_quantiles(x1, p1, x2, p2):
     sigma = (x2 - x1) / denom
     mu = (x1 * norm.ppf(p2) - x2 * norm.ppf(p1)) / denom
     return mu, sigma
+
+
+def null(a, rtol=1e-5):
+    u, s, v = np.linalg.svd(a)
+    rank = (s > rtol*s[0]).sum()
+    return v[rank:].T.copy()
+
+def rref(mat):
+    return sp.Matrix(mat).rref(iszerofunc=lambda x: abs(x)<1e-10)[0]

--- a/src/maud/utils.py
+++ b/src/maud/utils.py
@@ -58,8 +58,9 @@ def get_normal_parameters_from_quantiles(x1, p1, x2, p2):
 
 def null(a, rtol=1e-5):
     u, s, v = np.linalg.svd(a)
-    rank = (s > rtol*s[0]).sum()
+    rank = (s > rtol * s[0]).sum()
     return v[rank:].T.copy()
 
+
 def rref(mat):
-    return sp.Matrix(mat).rref(iszerofunc=lambda x: abs(x)<1e-10)[0]
+    return sp.Matrix(mat).rref(iszerofunc=lambda x: abs(x) < 1e-10)[0]

--- a/src/maud/utils.py
+++ b/src/maud/utils.py
@@ -56,13 +56,13 @@ def get_normal_parameters_from_quantiles(x1, p1, x2, p2):
     return mu, sigma
 
 
-def null(a, rtol=1e-5):
+def get_null_space(a, rtol=1e-5):
     """Calulate the null space of a matrix."""
     u, s, v = np.linalg.svd(a)
     rank = (s > rtol * s[0]).sum()
     return v[rank:].T.copy()
 
 
-def rref(mat):
+def get_rref(mat):
     """Return reduced row echelon form of a matrix."""
     return sp.Matrix(mat).rref(iszerofunc=lambda x: abs(x) < 1e-10)[0]


### PR DESCRIPTION
# Summary
Including a warning to the user about potentially under and over specified flux networks. This check is based on the stoichiometric matrix and DOF. It’s up to the user to determine if the fluxes are independent, for examples, measuring the input and output flux of a linear pathway would be 2 independent measurements. However, taking a single measurement and inferring the output flux and using that as a measurement is not independent.

# Commits
* feat: calculating null and rref
* feat: identifying undefined DOF and overspecified systems
* tests: satisfying style guides
* feat: including sympy in setup config
* adr: including the decision on validating the measured fluxes
* doc: adding doc strings

Checklist:

- [x] Updated any relevant documentation
- [x] Add an adr doc if appropriate
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [x] Integration tests passing

No changes to Maud’s operation or input files so integration testing is not required
