### PR TITLE
Check measured fluxes

### DIFF
--- a/docs/adr/0016-validating-measured-fluxes.md
+++ b/docs/adr/0016-validating-measured-fluxes.md
@@ -1,0 +1,50 @@
+# 16. checking that appropriate fluxes are measured
+
+Date: 2021-01-22
+
+## Status
+
+In Review
+
+## Context
+Defining the number of indenpendent fluxes isn't always clear.
+This is an issue as defining more fluxes than there are degrees
+of freedom when calculating the fluxes.
+
+An example would be this simplified network:
+
+	A -> B -> C
+
+where reaction 1 and reaction 2 are dependent, implying that
+no additional information is achieved by including both.
+
+Another issue is knowing when you do not have enough fluxes
+measured, resulting in an underdetermined system. Due to the
+Bayesian implementation of Maud, these systems are still theoretically
+resolvable. However, supplementing as much information
+as possible will likely be beneficial.
+
+## Decision
+Identifying underdetermined systems is acomplished by first calculating
+the null space of the matrix. This gives the number of degrees of freedom
+of the system as well. Then we calculate the reduced row echelon form of
+the transpose of the null space. The resulting matrix represents the
+independent flux pathways through the network as rows. If you take the
+measured subset of reactions and there is a row containing no non-zero
+entries then the system is not fully described using the current measurements.
+
+Determining if the system is overspecified is achieved by comparing the
+number of measurements to the degrees of freedom. If the number of measurements
+is larger than the degrees of freedom then the system is overdetermined.
+
+It is possible to both have an underdetermined system which is overspecified
+by having multiple measurements on dependent paths. It is also possible to
+recieve the warning that the system is overspecified by independent measurements.
+For instance, a linear pathway where the influx and efflux are both measured.
+This is still valid as they are independent measurements.
+
+## Consequences
+There are no direct consequences to the user, this effect Maud running in any
+way. The output of this feature may warn the user about possible biases present
+in the experiment definition. It is however completely up to the user to determine
+if these warnings apply to their notwork or not.

--- a/docs/adr/0016-validating-measured-fluxes.md
+++ b/docs/adr/0016-validating-measured-fluxes.md
@@ -7,9 +7,9 @@ Date: 2021-01-22
 In Review
 
 ## Context
-Defining the number of indenpendent fluxes isn't always clear.
-This is an issue as defining more fluxes than there are degrees
-of freedom when calculating the fluxes.
+Defining measurements for independent fluxes isn't always clear.
+This can occur when you measure more fluxes than there are degrees
+of freedom in a network.
 
 An example would be this simplified network:
 
@@ -44,7 +44,7 @@ For instance, a linear pathway where the influx and efflux are both measured.
 This is still valid as they are independent measurements.
 
 ## Consequences
-There are no direct consequences to the user, this effect Maud running in any
+There are no direct consequences to the user, this should not effect Maud sampling in any
 way. The output of this feature may warn the user about possible biases present
 in the experiment definition. It is however completely up to the user to determine
 if these warnings apply to their notwork or not.

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     arviz
     numpy
     scipy
+    sympy
     pandas
     matplotlib
     jinja2

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -191,7 +191,7 @@ def validate_specified_fluxes(
                     if st != 0:
                         possible_measurements.append(rxn)
                 msg = (
-                    "Your system appears to be underdetermined in"
+                    "\nYour system appears to be underdetermined in "
                     + f"experiment: {exp}\n"
                     + "Please define a reaction from the following list:\n"
                     + "\n".join(possible_measurements)

--- a/src/maud/sampling.py
+++ b/src/maud/sampling.py
@@ -191,17 +191,18 @@ def validate_specified_fluxes(
                     if st != 0:
                         possible_measurements.append(rxn)
                 msg = (
-                    f"Your system appears to be underdetermined in experiment:\n{exp}\n" +
-                    "Please define a reaction from the following list:\n"+
-                    f"{'\n'.join(possible_measurements)}"
+                    "Your system appears to be underdetermined in"
+                    + f"experiment: {exp}\n"
+                    + "Please define a reaction from the following list:\n"
+                    + "\n".join(possible_measurements)
                 )
                 warnings.warn(msg)
 
         if len(measured_rxn_list) > n_dof:
             msg = (
-                "You appear to have specified too many reactions.\n" +
-                "This will bias the statistical model\n"+
-                "as the measurements are not independent."
+                "You appear to have specified too many reactions.\n"
+                + "This will bias the statistical model\n"
+                + "as the measurements are not independent."
             )
             warnings.warn(msg)
 

--- a/src/maud/utils.py
+++ b/src/maud/utils.py
@@ -19,6 +19,7 @@
 from typing import Dict, Iterable
 
 import numpy as np
+import sympy as sp
 from scipy.stats import norm
 
 
@@ -53,3 +54,15 @@ def get_normal_parameters_from_quantiles(x1, p1, x2, p2):
     sigma = (x2 - x1) / denom
     mu = (x1 * norm.ppf(p2) - x2 * norm.ppf(p1)) / denom
     return mu, sigma
+
+
+def get_null_space(a, rtol=1e-5):
+    """Calulate the null space of a matrix."""
+    u, s, v = np.linalg.svd(a)
+    rank = (s > rtol * s[0]).sum()
+    return v[rank:].T.copy()
+
+
+def get_rref(mat):
+    """Return reduced row echelon form of a matrix."""
+    return sp.Matrix(mat).rref(iszerofunc=lambda x: abs(x) < 1e-10)[0]


### PR DESCRIPTION
Summary

Including a warning to the user about potentially under and over specified flux networks. This check is based on the stoichiometric matrix and DOF. It’s up to the user to determine if the fluxes are independent, for examples, measuring the input and output flux of a linear pathway would be 2 independent measurements. However, taking a single measurement and inferring the output flux and using that as a measurement is not independent.

Commits

feat: calculating null and rref
feat: identifying undefined DOF and overspecified systems
tests: satisfying style guides
feat: including sympy in setup config
adr: including the decision on validating the measured fluxes
doc: adding doc strings
Checklist:

  Updated any relevant documentation
  Add an adr doc if appropriate
  Include links to any relevant issues in the description
  Unit tests passing
  Integration tests passing
No changes to Maud’s operation or input files so integration testing is not required