### PR TITLE
Bug fix: drain priors are wrong

### DIFF
--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -284,7 +284,7 @@ def parse_prior_set_df(raw: pd.DataFrame) -> PriorSet:
         "phos_kcat_priors": [],
         "phos_enz_concentration_priors": [],
     }
-    negative_param_types = ["formation_energy"]
+    negative_param_types = ["formation_energy", "drain"]
     for _, row in raw.iterrows():
         id = "_".join(row.loc[lambda s: [isinstance(x, str) for x in s]].values)
         parameter_type = row["parameter_type"]


### PR DESCRIPTION
I think some of our models have been going wrong lately because the priors for drains have been set incorrectly, assuming a lognormal rather than a normal distribution.

This fix ensures they are in the list of parameters that are given normal priors. 

Checklist:

- [x] Updated any relevant documentation
- [x] Add an adr doc if appropriate
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [ ] Integration tests passing
