### PR TITLE
Generate init from run

### DIFF
--- a/src/maud/analysis.py
+++ b/src/maud/analysis.py
@@ -21,6 +21,13 @@ def load_infd(csvs: List[str], mi: MaudInput) -> az.InferenceData:
         **{
             "reactions": mi.stan_coords.reactions,
             "kms": join_list_of_strings(mi.stan_coords.km_enzs, mi.stan_coords.km_mics),
+            "kis": join_list_of_strings(mi.stan_coords.ci_enzs, mi.stan_coords.ci_mics),
+            "diss_ts": join_list_of_strings(
+                mi.stan_coords.ai_enzs, mi.stan_coords.ai_mics
+            ),
+            "diss_rs": join_list_of_strings(
+                mi.stan_coords.aa_enzs, mi.stan_coords.aa_mics
+            ),
             "yconcs": join_list_of_strings(
                 mi.stan_coords.yconc_exps, mi.stan_coords.yconc_mics
             ),
@@ -36,12 +43,21 @@ def load_infd(csvs: List[str], mi: MaudInput) -> az.InferenceData:
         csvs,
         coords=coords,
         dims={
-            "conc_enzyme": ["experiments", "enzymes"],
-            "conc": ["experiments", "mics"],
             "flux": ["experiments", "reactions"],
+            "conc": ["experiments", "mics"],
+            "conc_enzyme": ["experiments", "enzymes"],
+            "conc_unbalanced": ["experiments", "unbalanced_mics"],
+            "conc_phos": ["experiments", "phos_enzs"],
+            "drain": ["experiments", "drains"],
+            "diss_t": ["diss_ts"],
+            "diss_r": ["diss_rs"],
+            "transfer_constant": ["allosteric_enzymes"],
             "dgf": ["metabolites"],
+            "keq": ["edges"],
             "kcat": ["enzymes"],
+            "kcat_phos": ["phos_enzs"],
             "km": ["kms"],
+            "ki": ["kis"],
             "yconc_sim": ["yconcs"],
             "yflux_sim": ["yfluxs"],
             "yenz_sim": ["yenzs"],

--- a/src/maud/analysis.py
+++ b/src/maud/analysis.py
@@ -10,11 +10,12 @@ from matplotlib import pyplot as plt
 from maud.data_model import MaudInput
 
 
+def join_list_of_strings(l1, l2, sep="-"):
+        return list(map(lambda a: f"{a[0]}{sep}{a[1]}", zip(l1, l2)))
+
+
 def load_infd(csvs: List[str], mi: MaudInput) -> az.InferenceData:
     """Get an arviz InferenceData object from Maud csvs."""
-
-    def join_list_of_strings(l1, l2, sep="-"):
-        return list(map(lambda a: f"{a[0]}{sep}{a[1]}", zip(l1, l2)))
 
     coords = {
         **mi.stan_coords.__dict__,

--- a/src/maud/analysis.py
+++ b/src/maud/analysis.py
@@ -11,7 +11,7 @@ from maud.data_model import MaudInput
 
 
 def join_list_of_strings(l1, l2, sep="-"):
-        return list(map(lambda a: f"{a[0]}{sep}{a[1]}", zip(l1, l2)))
+    return list(map(lambda a: f"{a[0]}{sep}{a[1]}", zip(l1, l2)))
 
 
 def load_infd(csvs: List[str], mi: MaudInput) -> az.InferenceData:

--- a/src/maud/analysis.py
+++ b/src/maud/analysis.py
@@ -11,6 +11,7 @@ from maud.data_model import MaudInput
 
 
 def join_list_of_strings(l1, l2, sep="-"):
+    """Join strings for use in infd coordinates."""
     return list(map(lambda a: f"{a[0]}{sep}{a[1]}", zip(l1, l2)))
 
 

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -25,8 +25,8 @@ import toml
 
 from maud import sampling
 from maud.analysis import load_infd
-from maud.user_templates import get_inits_from_draw, get_prior_template
 from maud.io import load_maud_input_from_toml, parse_config, parse_toml_kinetic_model
+from maud.user_templates import get_inits_from_draw, get_prior_template
 
 
 RELATIVE_PATH_EXAMPLE = "../../tests/data/linear"

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -25,7 +25,7 @@ import toml
 
 from maud import sampling
 from maud.analysis import load_infd
-from maud.get_prior_template import get_init_descriptor, get_prior_template
+from maud.user_templates import get_inits_from_draw, get_prior_template
 from maud.io import load_maud_input_from_toml, parse_config, parse_toml_kinetic_model
 
 
@@ -182,7 +182,7 @@ def generate_inits(data_path, chain, draw, warmup):
     output_name = "generated_inits.csv"
     output_path = os.path.join(data_path, output_name)
     print("Creating init")
-    init_dataframe = get_init_descriptor(infd, mi, chain, draw, warmup)
+    init_dataframe = get_inits_from_draw(infd, mi, chain, draw, warmup)
     print(f"Saving inits to: {output_path}")
     init_dataframe.to_csv(output_path)
     return "Successfully generated prior template"

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -159,12 +159,17 @@ def generate_prior_template_command(data_path):
     click.echo(generate_prior_template(data_path))
 
 
-def generate_inits(data_path, chain, draw):
+def generate_inits(data_path, chain, draw, warmup):
     """Generate template for init definitions.
 
-    :params data_path: a path to a maud output folder with both a samples
-    and
-    :params chain: the sampling chain of the stan sampler
+    :params data_path: a path to a maud output folder with both samples
+    and user_input folders
+    :params chain: the sampling chain of the stan sampler you want to
+    export
+    :params draw: the sampling draw of the sampling chain you want to
+    export from the start of the sampling or warmup phase
+    :params warmup: indicator variable of if it is for the warmup
+    or sampling phase
     """
 
     csvs = [
@@ -177,7 +182,7 @@ def generate_inits(data_path, chain, draw):
     output_name = "generated_inits.csv"
     output_path = os.path.join(data_path, output_name)
     print("Creating init")
-    init_dataframe = get_init_descriptor(infd, mi, chain, draw)
+    init_dataframe = get_init_descriptor(infd, mi, chain, draw, warmup)
     print(f"Saving inits to: {output_path}")
     init_dataframe.to_csv(output_path)
     return "Successfully generated prior template"
@@ -189,7 +194,9 @@ def generate_inits(data_path, chain, draw):
     type=click.Path(exists=True, dir_okay=True, file_okay=False),
 )
 @click.option("--chain", default=0, help="Sampling chain using python indexing")
-@click.option("--draw", default=0, help="Sampling draw using python indexing")
-def generate_inits_command(data_path, chain, draw):
+@click.option("--draw", default=0, help="Sampling draw using python indexing from start of phase")
+@click.option("--warmup", default=0, help="0 if in sampling, 1 if in warmup phase")
+
+def generate_inits_command(data_path, chain, draw, warmup):
     """Run the generate_inits function as a click command."""
-    click.echo(generate_inits(data_path, chain, draw))
+    click.echo(generate_inits(data_path, chain, draw, warmup))

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -194,9 +194,10 @@ def generate_inits(data_path, chain, draw, warmup):
     type=click.Path(exists=True, dir_okay=True, file_okay=False),
 )
 @click.option("--chain", default=0, help="Sampling chain using python indexing")
-@click.option("--draw", default=0, help="Sampling draw using python indexing from start of phase")
+@click.option(
+    "--draw", default=0, help="Sampling draw using python indexing from start of phase"
+)
 @click.option("--warmup", default=0, help="0 if in sampling, 1 if in warmup phase")
-
 def generate_inits_command(data_path, chain, draw, warmup):
     """Run the generate_inits function as a click command."""
     click.echo(generate_inits(data_path, chain, draw, warmup))

--- a/src/maud/get_prior_template.py
+++ b/src/maud/get_prior_template.py
@@ -80,6 +80,7 @@ def get_2d_coords(coords_1, coords_2):
 
 
 def get_parameter_coords(scs):
+    """Define parameter coordinates for stan and infd objects."""
     return [
         Input_Coords(
             id="km",
@@ -161,7 +162,7 @@ def get_parameter_coords(scs):
 
 
 def get_prior_template(km, raw_measurements):
-    """Gets prior dataframe from KineticModel and Measurements."""
+    """Get prior dataframe from KineticModel and Measurements."""
 
     scs = get_stan_coords(km, raw_measurements)
     list_of_input_inits = get_parameter_coords(scs)

--- a/src/maud/get_prior_template.py
+++ b/src/maud/get_prior_template.py
@@ -188,12 +188,14 @@ def get_init_descriptor(infd, mi, chain, draw, warmup):
         if par.id in infd_parameters:
             if warmup == 1:
                 value_dataframe = (
-                infd.warmup_posterior[par.id][chain][draw].to_dataframe().reset_index()
+                    infd.warmup_posterior[par.id][chain][draw]
+                    .to_dataframe()
+                    .reset_index()
                 )
 
             else:
                 value_dataframe = (
-                infd.posterior[par.id][chain][draw].to_dataframe().reset_index()
+                    infd.posterior[par.id][chain][draw].to_dataframe().reset_index()
                 )
             par_dataframe = pd.DataFrame.from_dict(par.coords)
             if par.linking_list:

--- a/src/maud/get_prior_template.py
+++ b/src/maud/get_prior_template.py
@@ -20,8 +20,8 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 
-from maud.io import get_stan_coords
 from maud.analysis import join_list_of_strings
+from maud.io import get_stan_coords
 
 
 PRIOR_FILE_COLUMNS = [

--- a/src/maud/get_prior_template.py
+++ b/src/maud/get_prior_template.py
@@ -21,6 +21,7 @@ from typing import Dict, List, Optional
 import pandas as pd
 
 from maud.io import get_stan_coords
+from maud.analysis import join_list_of_strings
 
 
 PRIOR_FILE_COLUMNS = [
@@ -67,10 +68,6 @@ class Input_Coords:
         self.coords = coords
         self.infd_coord_list = infd_coord_list
         self.linking_list = linking_list
-
-
-def join_list_of_strings(l1, l2, sep="-"):
-    return list(map(lambda a: f"{a[0]}{sep}{a[1]}", zip(l1, l2)))
 
 
 def get_2d_coords(coords_1, coords_2):

--- a/src/maud/user_templates.py
+++ b/src/maud/user_templates.py
@@ -54,7 +54,9 @@ class Input_Coords:
     """Defines parameters with associated coordinate sets.
 
     :param id: id of the parameter.
-    :param coords: dictionary.
+    :param coords: dictionary of user input keys with corresponding list of ordered ids.
+    :param infd_coord_list: ordered list that matches the coords to the infd object.
+    :param linking_list: matches composite strings to the infd coords.
     """
 
     def __init__(
@@ -175,7 +177,7 @@ def get_prior_template(km, raw_measurements):
     return prior_dataframe
 
 
-def get_init_descriptor(infd, mi, chain, draw, warmup):
+def get_inits_from_draw(infd, mi, chain, draw, warmup):
     """Extact parameters from an infd object."""
 
     scs = mi.stan_coords

--- a/tests/data/example_features/drain/kinetic_model.toml
+++ b/tests/data/example_features/drain/kinetic_model.toml
@@ -37,28 +37,28 @@ compartment = 'c'
 id = 'r1'
 name = 'reaction number 1'
 stoichiometry = { M1_e = -1, M1_c = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r1'
 name = 'the enzyme that catalyses reaction r1'
-mechanism = "reversible_modular_rate_law"
 
 [[reactions]]
 id = 'r2'
 name = 'reaction number 2'
 stoichiometry = { M1_c = -1, M2_c = 1 }
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r2'
 name = 'the enzyme that catalyses reaction r2'
-mechanism = "reversible_modular_rate_law"
 
 [[reactions]]
 id = 'r3'
 name = 'reaction number 3'
 stoichiometry = { M2_c = -1, M2_e = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r3'
 name = 'the enzyme that catalyses reaction r3'
-mechanism = "reversible_modular_rate_law"
 
 [[drains]]
 id = "M2_e_drain"

--- a/tests/data/example_features/michaelis_menten/kinetic_model.toml
+++ b/tests/data/example_features/michaelis_menten/kinetic_model.toml
@@ -36,26 +36,27 @@ compartment = 'c'
 id = 'r1'
 name = 'reaction number 1'
 stoichiometry = { M1_e = -1, M1_c = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r1'
 name = 'the enzyme that catalyses reaction r1'
-mechanism = "reversible_modular_rate_law"
+
 
 [[reactions]]
 id = 'r2'
 name = 'reaction number 2'
 stoichiometry = { M1_c = -1, M2_c = 1 }
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r2'
 name = 'the enzyme that catalyses reaction r2'
-mechanism = "reversible_modular_rate_law"
 
 [[reactions]]
 id = 'r3'
 name = 'reaction number 3'
 stoichiometry = { M2_c = -1, M2_e = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r3'
 name = 'the enzyme that catalyses reaction r3'
-mechanism = "reversible_modular_rate_law"
 

--- a/tests/data/example_features/one_allosteric_modifier/kinetic_model.toml
+++ b/tests/data/example_features/one_allosteric_modifier/kinetic_model.toml
@@ -36,10 +36,10 @@ compartment = 'c'
 id = 'r1'
 name = 'reaction number 1'
 stoichiometry = { M1_e = -1, M1_c = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r1'
 name = 'the enzyme that catalyses reaction r1'
-mechanism = "reversible_modular_rate_law"
 subunits=4
 [[reactions.enzymes.modifiers]]
 modifier_type = 'allosteric_inhibitor'
@@ -49,16 +49,17 @@ mic_id = 'M2_c'
 id = 'r2'
 name = 'reaction number 2'
 stoichiometry = { M1_c = -1, M2_c = 1 }
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r2'
 name = 'the enzyme that catalyses reaction r2'
-mechanism = "reversible_modular_rate_law"
+
 
 [[reactions]]
 id = 'r3'
 name = 'reaction number 3'
 stoichiometry = { M2_c = -1, M2_e = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r3'
 name = 'the enzyme that catalyses reaction r3'
-mechanism = "reversible_modular_rate_law"

--- a/tests/data/example_features/phosphorylation/kinetic_model.toml
+++ b/tests/data/example_features/phosphorylation/kinetic_model.toml
@@ -36,10 +36,10 @@ compartment = 'c'
 id = 'r1'
 name = 'reaction number 1'
 stoichiometry = { M1_e = -1, M1_c = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r1'
 name = 'the enzyme that catalyses reaction r1'
-mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes.modifiers]]
 modifier_type = 'allosteric_activator'
 mic_id = 'M2_c'
@@ -48,10 +48,10 @@ mic_id = 'M2_c'
 id = 'r2'
 name = 'reaction number 2'
 stoichiometry = { M1_c = -1, M2_c = 1 }
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r2'
 name = 'the enzyme that catalyses reaction r2'
-mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes.modifiers]]
 modifier_type = 'allosteric_inhibitor'
 mic_id = 'M1_c'
@@ -63,10 +63,10 @@ mic_id = 'M2_c'
 id = 'r3'
 name = 'reaction number 3'
 stoichiometry = { M2_c = -1, M2_e = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r3'
 name = 'the enzyme that catalyses reaction r3'
-mechanism = "reversible_modular_rate_law"
 
 [[phosphorylation]]
 id = "p2"

--- a/tests/data/example_features/two_allosteric_modifiers/kinetic_model.toml
+++ b/tests/data/example_features/two_allosteric_modifiers/kinetic_model.toml
@@ -36,10 +36,10 @@ compartment = 'c'
 id = 'r1'
 name = 'reaction number 1'
 stoichiometry = { M1_e = -1, M1_c = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r1'
 name = 'the enzyme that catalyses reaction r1'
-mechanism = "reversible_modular_rate_law"
 subunits=4
 [[reactions.enzymes.modifiers]]
 modifier_type = 'allosteric_activator'
@@ -52,16 +52,16 @@ mic_id = 'M1_c'
 id = 'r2'
 name = 'reaction number 2'
 stoichiometry = { M1_c = -1, M2_c = 1 }
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r2'
 name = 'the enzyme that catalyses reaction r2'
-mechanism = "reversible_modular_rate_law"
 
 [[reactions]]
 id = 'r3'
 name = 'reaction number 3'
 stoichiometry = { M2_c = -1, M2_e = 1}
+mechanism = "reversible_modular_rate_law"
 [[reactions.enzymes]]
 id = 'r3'
 name = 'the enzyme that catalyses reaction r3'
-mechanism = "reversible_modular_rate_law"


### PR DESCRIPTION
# Summary:

inits can now be generated and used in Maud through the command `maud generate-inits <data_path> --chain=<chain_number (Python Indexing)> --draw=<draw_number (Python Indexing)> --warmup=<warmup phase=1 or sampling phase=0>`. This will then generate an inits file to use for initialising samples and tuning ODE solvers.

# Motivation:
Initial conditions are extremely useful for many conditions. Tuning the ODE parameters cannot be done far away from the typical set because these systems typically blow up and aren'y representative of the systems you want to sample on. Therefore, using an initial value to tune the ODE parameters is extremely beneficial. Furthermore, initialising your sampling around a point makes the warmup phase more robust, as it doesn't have to travel as far to find the typical set.

Checklist:

- [x] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [x] Unit tests passing
- [ ] Integration tests passing
