### PR TITLE
feat: changing steady state evaluation to relative

### DIFF
--- a/src/maud/model.stan
+++ b/src/maud/model.stan
@@ -388,7 +388,7 @@ transformed parameters {
     for (j in 1:N_edge)
       flux[e, edge_to_reaction[j]] += flux_edge[j];
     }
-    if (squared_distance(conc_balanced[1], conc_balanced[2]) > 1){
+    if (sum((conc_balanced[1]-conc_balanced[2])./conc_balanced[2]) > 0.001){
       print("Balanced metabolite concentration at ", timepoint, " seconds is not steady.");
       print("Found ", conc_balanced[1], " at ", timepoint, " seconds and ",
             conc_balanced[2], " at ", timepoint + 10, " seconds.");


### PR DESCRIPTION
# Summary

updating the steady state evaluation so it's independent of the absolute scale of the metabolites. evaluates it 10 seconds in the future and checks if the sum of relative metabolite changes is less than 0.001 of that.

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [ ] Unit tests passing
- [ ] Integration tests passing
