### PR TITLE
Bug: make arviz disable numba when loading InferenceData

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,7 @@ exclude = '''
     | _version.py
 )
 '''
+
+[tool.pyright]
+venvPath = "./venv_maud"
+venv = "venv_maud"

--- a/src/maud/analysis.py
+++ b/src/maud/analysis.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Union
 
 import arviz as az
 import numpy as np
+from arviz.utils import Numba
 from matplotlib import pyplot as plt
 
 from maud.data_model import MaudInput
@@ -18,6 +19,7 @@ def join_list_of_strings(l1, l2, sep="-"):
 def load_infd(csvs: List[str], mi: MaudInput) -> az.InferenceData:
     """Get an arviz InferenceData object from Maud csvs."""
 
+    Numba.disable_numba()
     coords = {
         **mi.stan_coords.__dict__,
         **{


### PR DESCRIPTION
I hit an error in the demo notebook because of a library called Numba. Arviz tries to use it for a speedup if it's installed, but sometimes it seems to cause an error. This change fixed it on my computer.

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [x] Unit tests passing
- [ ] Integration tests passing
