### PR TITLE
Bug: fix wrong index in enzyme concentration likelihood function

### DIFF
--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -511,15 +511,12 @@ def extract_2d_prior(
     out = raw.loc[lambda df: df["parameter_type"] == parameter_name].set_index(
         parameter_name_to_id_cols[parameter_name]
     )
-    pct_params = (
-        out[["pct1", "pct99"]]
-        .apply(
-            lambda row: qfunc(row["pct1"], 0.01, row["pct99"], 0.99),
-            axis=1,
-            result_type="expand",
-        )
-        .rename(columns={0: "location", 1: "scale"})
+    pct_params = out[["pct1", "pct99"]].apply(
+        lambda row: qfunc(row["pct1"], 0.01, row["pct99"], 0.99),
+        axis=1,
+        result_type="expand",
     )
+    pct_params.columns = ["location", "scale"]
     pct_params["location"] = np.exp(pct_params["location"])
     out[["location", "scale"]] = out[["location", "scale"]].fillna(pct_params)
     location, scale = (

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -520,6 +520,7 @@ def extract_2d_prior(
         )
         .rename(columns={0: "location", 1: "scale"})
     )
+    pct_params["location"] = np.exp(pct_params["location"])
     out[["location", "scale"]] = out[["location", "scale"]].fillna(pct_params)
     location, scale = (
         out[col]

--- a/src/maud/model.stan
+++ b/src/maud/model.stan
@@ -430,7 +430,7 @@ model {
     for (c in 1:N_conc_measurement)
       yconc[c] ~ lognormal(log(conc[experiment_yconc[c], mic_ix_yconc[c]]), sigma_conc[c]);
     for (e in 1:N_enzyme_measurement)
-      yenz[e] ~ lognormal(log(conc_enzyme[experiment_yconc[e], enzyme_yenz[e]]), sigma_enz[e]);
+      yenz[e] ~ lognormal(log(conc_enzyme[experiment_yenz[e], enzyme_yenz[e]]), sigma_enz[e]);
     for (f in 1:N_flux_measurement)
       yflux[f] ~ normal(flux[experiment_yflux[f], reaction_yflux[f]], sigma_flux[f]);
   }


### PR DESCRIPTION
I found this quite big bug while preparing the demo notebook for the workshop - it might explain if any complicated models have been a bit off recently!

I also bundled a second bugfix that was causing an error when trying to set 2D priors using percentiles. I just copied the equivalent line from the function `extract_1d_prior`.

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [x] Unit tests passing
- [ ] Integration tests passing
