### PR TITLE
bug: make defining inits possible for multivariate dgf

### DIFF
--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -662,7 +662,7 @@ def get_inits(priors: PriorSet, user_inits_path) -> Dict[str, np.array]:
     ) -> pd.Series:
         if len(p.location) == 0:
             return p.location
-        elif isinstance(p, IndPrior1d):
+        elif isinstance(p, IndPrior1d) or isinstance(p, MultiVariateNormalPrior1d):
             return u.loc[lambda df: df["parameter_name"] == p.parameter_name].set_index(
                 p.location.index.names
             )["value"]


### PR DESCRIPTION
# Summary

Given a multivariate specification, the MultiVariateNormalPrior1d data type is not specified in the get_inits() function. This fixes that.

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [ ] Unit tests passing
- [ ] Integration tests passing
