### PR TITLE
Experiment slicing

### DIFF
--- a/scripts/export-yaml.py
+++ b/scripts/export-yaml.py
@@ -156,7 +156,7 @@ def main():
     warmup = bool(args.warmup)
     yaml_output = os.path.join(HERE, args.yaml_output)
     csvs = get_csvs(maud_output_dir)
-    mi = load_maud_input(os.path.join(maud_output_dir, "user_input"))
+    mi = load_maud_input(os.path.join(maud_output_dir, "user_input"), mode="sample")
     infd = load_infd(csvs, mi)
     selected_experiment = None
     if selected_experiment is None:

--- a/scripts/export-yaml.py
+++ b/scripts/export-yaml.py
@@ -151,9 +151,9 @@ def main():
     )
     args = parser.parse_args()
     maud_output_dir = args.maud_output_dir[0]
-    chain = args.chain
-    draw = args.draw
-    warmup = args.warmup
+    chain = int(args.chain)
+    draw = int(args.draw)
+    warmup = bool(args.warmup)
     yaml_output = os.path.join(HERE, args.yaml_output)
     csvs = get_csvs(maud_output_dir)
     mi = load_maud_input(os.path.join(maud_output_dir, "user_input"))

--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -248,7 +248,8 @@ class MeasurementSet:
 
 
 class Experiment:
-    """Constructor for Experiment object
+    """Constructor for Experiment object.
+
     :param id: id for each experiment
     :param sample: if the experiment will be used in parameter sampling
     :param predict: if the experiment will be used in predictive samplig
@@ -429,7 +430,7 @@ class MaudInput:
         priors: PriorSet,
         stan_coords: StanCoordSet,
         measurements: MeasurementSet,
-        experiments: List[Experiment],
+        all_experiments: List[Experiment],
         inits: Dict[str, np.array],
     ):
         self.config = config
@@ -437,7 +438,7 @@ class MaudInput:
         self.priors = priors
         self.stan_coords = stan_coords
         self.measurements = measurements
-        self.experiments = experiments
+        self.all_experiments = all_experiments
         self.inits = inits
 
 

--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -247,6 +247,19 @@ class MeasurementSet:
     phos_knockouts: pd.DataFrame
 
 
+class Experiment:
+    """Constructor for Experiment object
+    :param id: id for each experiment
+    :param sample: if the experiment will be used in parameter sampling
+    :param predict: if the experiment will be used in predictive samplig
+    """
+
+    def __init__(self, id: str, sample: bool, predict: bool):
+        self.id = id
+        self.sample = sample
+        self.predict = predict
+
+
 @dataclass
 class IndPrior1d:
     """Independent location/scale prior for a 1-dimentional parameter."""
@@ -375,7 +388,8 @@ class MaudConfig:
         name: str,
         kinetic_model_file: str,
         priors_file: str,
-        experiments_file: str,
+        measurements_file: str,
+        biological_config_file: str,
         likelihood: bool,
         reject_non_steady: Optional[bool],
         ode_config: dict,
@@ -387,7 +401,8 @@ class MaudConfig:
         self.name = name
         self.kinetic_model_file = kinetic_model_file
         self.priors_file = priors_file
-        self.experiments_file = experiments_file
+        self.measurements_file = measurements_file
+        self.biological_config_file = biological_config_file
         self.likelihood = likelihood
         self.reject_non_steady = reject_non_steady
         self.ode_config = ode_config
@@ -414,6 +429,7 @@ class MaudInput:
         priors: PriorSet,
         stan_coords: StanCoordSet,
         measurements: MeasurementSet,
+        experiments: List[Experiment],
         inits: Dict[str, np.array],
     ):
         self.config = config
@@ -421,6 +437,7 @@ class MaudInput:
         self.priors = priors
         self.stan_coords = stan_coords
         self.measurements = measurements
+        self.experiments = experiments
         self.inits = inits
 
 

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -128,7 +128,7 @@ def load_maud_input(data_path: str, mode: str) -> MaudInput:
         priors=prior_set,
         stan_coords=stan_coords,
         measurements=measurement_set,
-        experiments=experiments,
+        all_experiments=all_experiments,
         inits=inits,
     )
     validation.validate_maud_input(mi)
@@ -209,7 +209,10 @@ def get_stan_coords(
     This function is responsible for setting the order of each parameter.
 
     :param km: KineticModel object
-    :param ms: MeasurementSet object
+    :param raw_measurements: MeasurementSet object
+    :param all_experiments: List of Experiment object,
+    all experiments in biological config file
+    :param mode: "sample" or "predict" determine which experiments will be used
     """
 
     def unpack(packed):

--- a/src/maud/maud_utils/plot_oos.py
+++ b/src/maud/maud_utils/plot_oos.py
@@ -62,7 +62,7 @@ def plot_box_plots(var, draws, measurements, variable_id_map):
 
 def plot_oos(maud_oos_dir, output_dir):
     """Save boxplots given maud oos predictions and ourput_dir."""
-    mi = io.load_maud_input(maud_oos_dir / "user_input")
+    mi = io.load_maud_input(data_path=maud_oos_dir / "user_input", mode="predict")
     flux_df = pd.read_csv(maud_oos_dir / "oos_samples" / "flux.csv")
     conc_df = pd.read_csv(maud_oos_dir / "oos_samples" / "conc.csv")
     conc_enzyme_df = pd.read_csv(maud_oos_dir / "oos_samples" / "conc_enzyme.csv")

--- a/src/maud/maud_utils/plot_samples.py
+++ b/src/maud/maud_utils/plot_samples.py
@@ -204,7 +204,7 @@ def plot_posteriors(maud_output_dir, output_dir):
     """Plot posterior distributions of Maud model."""
     # Collecting information from draws and maud input
     csvs = list(Path(maud_output_dir / "samples").rglob("*.csv"))
-    mi = io.load_maud_input(maud_output_dir / "user_input")
+    mi = io.load_maud_input(data_path=maud_output_dir / "user_input", mode="sample")
     parameter_coords = get_parameter_coords(mi.stan_coords)
     infd = load_infd(csvs, mi)
     list_of_model_variables = list(infd.posterior.variables.keys())

--- a/src/maud/user_templates.py
+++ b/src/maud/user_templates.py
@@ -164,10 +164,10 @@ def get_parameter_coords(scs):
     ]
 
 
-def get_prior_template(km, raw_measurements):
+def get_prior_template(km, raw_measurements, experiments, mode):
     """Get prior dataframe from KineticModel and Measurements."""
 
-    scs = get_stan_coords(km, raw_measurements)
+    scs = get_stan_coords(km, raw_measurements, experiments, mode)
     list_of_input_inits = get_parameter_coords(scs)
     prior_dataframe = pd.DataFrame(columns=PRIOR_FILE_COLUMNS)
     for par in list_of_input_inits:

--- a/tests/data/ecoli_small/config.toml
+++ b/tests/data/ecoli_small/config.toml
@@ -5,7 +5,8 @@ description = """
 """
 kinetic_model = "kinetic_model.toml"
 priors = "priors.csv"
-experiments = "experiments.csv"
+measurements = "experiments.csv"
+biological_config = "biological_config.toml"
 likelihood = true
 
 [cmdstanpy_config]

--- a/tests/data/example_features/drain/biological_config.toml
+++ b/tests/data/example_features/drain/biological_config.toml
@@ -1,0 +1,9 @@
+[[experiment]]
+id = "condition_1"
+sample = true
+predict = true
+
+[[experiment]]
+id = "condition_2"
+sample = true
+predict = true

--- a/tests/data/example_features/drain/config.toml
+++ b/tests/data/example_features/drain/config.toml
@@ -1,7 +1,8 @@
 name = "linear_drain"
 kinetic_model = "kinetic_model.toml"
 priors = "priors.csv"
-experiments = "experiments.csv"
+measurements = "experiments.csv"
+biological_config = "biological_config.toml"
 likelihood = true
 
 [cmdstanpy_config]

--- a/tests/data/example_features/michaelis_menten/biological_config.toml
+++ b/tests/data/example_features/michaelis_menten/biological_config.toml
@@ -1,0 +1,9 @@
+[[experiment]]
+id = "condition_1"
+sample = true
+predict = true
+
+[[experiment]]
+id = "condition_2"
+sample = true
+predict = true

--- a/tests/data/example_features/michaelis_menten/config.toml
+++ b/tests/data/example_features/michaelis_menten/config.toml
@@ -1,7 +1,8 @@
 name = "linear_MM"
 kinetic_model = "kinetic_model.toml"
 priors = "priors.csv"
-experiments = "experiments.csv"
+measurements = "experiments.csv"
+biological_config = "biological_config.toml"
 likelihood = true
 
 [cmdstanpy_config]

--- a/tests/data/example_features/one_allosteric_modifier/biological_config.toml
+++ b/tests/data/example_features/one_allosteric_modifier/biological_config.toml
@@ -1,0 +1,9 @@
+[[experiment]]
+id = "condition_1"
+sample = true
+predict = true
+
+[[experiment]]
+id = "condition_2"
+sample = true
+predict = true

--- a/tests/data/example_features/one_allosteric_modifier/config.toml
+++ b/tests/data/example_features/one_allosteric_modifier/config.toml
@@ -1,7 +1,8 @@
 name = "linear_1_allo"
 kinetic_model = "kinetic_model.toml"
 priors = "priors.csv"
-experiments = "experiments.csv"
+measurements = "experiments.csv"
+biological_config = "biological_config.toml"
 likelihood = true
 
 [cmdstanpy_config]

--- a/tests/data/example_features/phosphorylation/biological_config.toml
+++ b/tests/data/example_features/phosphorylation/biological_config.toml
@@ -1,0 +1,9 @@
+[[experiment]]
+id = "condition_1"
+sample = true
+predict = true
+
+[[experiment]]
+id = "condition_2"
+sample = true
+predict = true

--- a/tests/data/example_features/phosphorylation/config.toml
+++ b/tests/data/example_features/phosphorylation/config.toml
@@ -1,7 +1,8 @@
 name = "linear_phos"
 kinetic_model = "kinetic_model.toml"
 priors = "priors.csv"
-experiments = "experiments.csv"
+measurements = "experiments.csv"
+biological_config = "biological_config.toml"
 likelihood = true
 
 [cmdstanpy_config]

--- a/tests/data/example_features/two_allosteric_modifiers/biological_config.toml
+++ b/tests/data/example_features/two_allosteric_modifiers/biological_config.toml
@@ -1,0 +1,9 @@
+[[experiment]]
+id = "condition_1"
+sample = true
+predict = true
+
+[[experiment]]
+id = "condition_2"
+sample = true
+predict = true

--- a/tests/data/example_features/two_allosteric_modifiers/config.toml
+++ b/tests/data/example_features/two_allosteric_modifiers/config.toml
@@ -1,7 +1,8 @@
 name = "linear_2_allo"
 kinetic_model = "kinetic_model.toml"
 priors = "priors.csv"
-experiments = "experiments.csv"
+measurements = "experiments.csv"
+biological_config = "biological_config.toml"
 likelihood = true
 
 [cmdstanpy_config]

--- a/tests/data/example_ode/biological_config.toml
+++ b/tests/data/example_ode/biological_config.toml
@@ -1,0 +1,4 @@
+[[experiment]]
+id = "condition_1"
+sample = true
+predict = true

--- a/tests/data/example_ode/config.toml
+++ b/tests/data/example_ode/config.toml
@@ -1,7 +1,8 @@
 name = "test-ode"
 kinetic_model = "kinetic_model.toml"
 priors = "priors.csv"
-experiments = "experiments.csv"
+measurements = "experiments.csv"
+biological_config = "biological_config.toml"
 likelihood = true
 
 [cmdstanpy_config]

--- a/tests/data/linear/biological_config.toml
+++ b/tests/data/linear/biological_config.toml
@@ -1,0 +1,9 @@
+[[experiment]]
+id = "condition_1"
+sample = true
+predict = true
+
+[[experiment]]
+id = "condition_2"
+sample = true
+predict = true

--- a/tests/data/linear/config.toml
+++ b/tests/data/linear/config.toml
@@ -1,7 +1,8 @@
 name = "linear"
 kinetic_model = "kinetic_model.toml"
 priors = "priors.csv"
-experiments = "experiments.csv"
+measurements = "experiments.csv"
+biological_config = "biological_config.toml"
 likelihood = true
 
 [cmdstanpy_config]

--- a/tests/test_unit/test_io.py
+++ b/tests/test_unit/test_io.py
@@ -22,7 +22,7 @@ def test_load_maud_input():
         "phos_enzs": [],
         "drains": [],
     }
-    mi = io.load_maud_input(os.path.join(data_path, "linear"))
+    mi = io.load_maud_input(data_path=os.path.join(data_path, "linear"), mode="sample")
     r1 = [r for r in mi.kinetic_model.reactions if r.id == "r1"][0]
     assert r1.stoichiometry == {"M1_e": -1, "M1_c": 1}
     assert "r1" in mi.priors.priors_kcat.location.reset_index()["enzyme_id"].values

--- a/tests/test_unit/test_sampling.py
+++ b/tests/test_unit/test_sampling.py
@@ -16,7 +16,7 @@ data_path = os.path.join(here, "..", "data")
 def test_get_input_data():
     """Test that the function get_input_data behaves as expected."""
     input_path = os.path.join(data_path, "linear")
-    mi = io.load_maud_input(input_path)
+    mi = io.load_maud_input(input_path, mode="sample")
     with open(os.path.join(input_path, "linear.json"), "r") as f:
         expected_input_data = json.load(f)
     actual_input_data = sampling.get_input_data(mi)


### PR DESCRIPTION
# Summary
Including the file to separate experiments based on `sample` or `predict` flag. This makes separation of validation and training sets easier. Here is an example of the proposed setup:

```
[[experiment]]
id = "<experiment id>"
sample = "<true/false if it will be used in sampling/simulation>"
predict = "<true/false if it will be used in prediction aspect>"
```

Both values can be `true` or `false`

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [x] Unit tests passing
- [x] Integration tests passing
