### PR TITLE
Bug: add missing "sample" argument to function call in dgf script

### DIFF
--- a/scripts/get_dgf_priors_from_equilibrator.py
+++ b/scripts/get_dgf_priors_from_equilibrator.py
@@ -83,7 +83,7 @@ def main():
     )
     maud_input_dir = parser.parse_args().maud_input_dir[0]
     if os.path.exists(maud_input_dir):
-        mi = load_maud_input(maud_input_dir)
+        mi = load_maud_input(maud_input_dir, "sample")
         mu, cov = get_dgf_priors(mi)
         print("Prior mean vector:")
         print(mu)


### PR DESCRIPTION
This change fixes a bug in the script for fetching dgf priors from equilibrator: currently the call to `load_maud_input_from_toml` is missing the `mode` argument.

Checklist:

- [ ] Updated any relevant documentation NA
- [ ] Add an adr doc if appropriate NA
- [ ] Include links to any relevant issues in the description NA
- [x] Unit tests passing
- [ ] Integration tests passing NA
