### PR TITLE
Install cmdstan from github develop branch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     matplotlib
     jinja2
     toml
-    cmdstanpy @ "git+https://github.com/stan-dev/cmdstanpy@develop#egg=cmdstanpy"
+    cmdstanpy @ "git+https://github.com/stan-dev/cmdstanpy.git@develop#egg=cmdstanpy"
     click
     depinfo
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     matplotlib
     jinja2
     toml
-    cmdstanpy @"git+https://github.com/stan-dev/cmdstanpy.git@develop"
+    cmdstanpy@git+https://github.com/stan-dev/cmdstanpy.git@develop
     click
     depinfo
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     matplotlib
     jinja2
     toml
-    cmdstanpy >=0.9.2
+    cmdstanpy @ "git+https://github.com/stan-dev/cmdstanpy@/develop#egg=cmdstanpy"
     click
     depinfo
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     matplotlib
     jinja2
     toml
-    cmdstanpy @ "git+https://github.com/stan-dev/cmdstanpy.git@develop#egg=cmdstanpy"
+    cmdstanpy @"git+https://github.com/stan-dev/cmdstanpy.git@develop"
     click
     depinfo
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     matplotlib
     jinja2
     toml
-    cmdstanpy @ "git+https://github.com/stan-dev/cmdstanpy@/develop#egg=cmdstanpy"
+    cmdstanpy @ "git+https://github.com/stan-dev/cmdstanpy@develop#egg=cmdstanpy"
     click
     depinfo
     tqdm


### PR DESCRIPTION
This should hopefully fix issue #371. The bug was fixed in cmdstanpy but hasn't been released yet (see https://github.com/stan-dev/cmdstanpy/pull/507). The easiest fix seemed like installing the latest cmdstanpy for now. Once a version of cmdstanpy without this bug is released we can change again to installing from pyPI

Checklist:

- [ ] Updated any relevant documentation NA
- [ ] Add an adr doc if appropriate NA
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [ ] Integration tests passing NA
