### PR TITLE
Bug: make dgf script work with specified but non-existing csvs

### DIFF
--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -92,6 +92,10 @@ def load_maud_input(data_path: str, mode: str) -> MaudInput:
     raw_biological_config = dict(toml.load(biological_config_path))
     measurements_path = os.path.join(data_path, config.measurements_file)
     priors_path = os.path.join(data_path, config.priors_file)
+    dgf_prior_paths = {
+        "loc": os.path.join(data_path, str(config.dgf_mean_file)),
+        "cov": os.path.join(data_path, str(config.dgf_covariance_file)),
+    }
     all_experiments = get_all_experiment_object(raw_biological_config)
     kinetic_model = parse_toml_kinetic_model(raw_kinetic_model)
     raw_measurements = pd.read_csv(measurements_path)
@@ -100,20 +104,17 @@ def load_maud_input(data_path: str, mode: str) -> MaudInput:
         kinetic_model, raw_measurements, all_experiments, mode
     )
     measurement_set = parse_measurements(raw_measurements, stan_coords)
-    if config.dgf_mean_file is not None:
+    if os.path.exists(dgf_prior_paths["loc"]):
         dgf_loc = pd.Series(
-            pd.read_csv(
-                os.path.join(data_path, config.dgf_mean_file), index_col="metabolite"
-            )["prior_mean_dgf"]
+            pd.read_csv(dgf_prior_paths["loc"], index_col="metabolite")[
+                "prior_mean_dgf"
+            ]
         )
     else:
         dgf_loc = pd.Series([])
-    if config.dgf_covariance_file is not None:
+    if os.path.exists(dgf_prior_paths["cov"]):
         dgf_cov = pd.DataFrame(
-            pd.read_csv(
-                os.path.join(data_path, config.dgf_covariance_file),
-                index_col="metabolite",
-            )
+            pd.read_csv(dgf_prior_paths["cov"], index_col="metabolite")
         )
     else:
         dgf_cov = pd.DataFrame([])


### PR DESCRIPTION
Fixes a bug that @ShannaraTP found: if `config.toml` specifies some dgf prior files that don't yet exist, the script `get_dgf_priors_from_equilibrator.py` fails. The fix is to change `io.py` so that instead of checking if the files are specified in `config.toml`, it instead checks whether they exist.

Checklist:

- [ ] Updated any relevant documentation NA
- [ ] Add an adr doc if appropriate NA
- [ ] Include links to any relevant issues in the description NA
- [x] Unit tests passing
- [ ] Integration tests passing NA
