### PR TITLE
Improved steady state checking

### DIFF
--- a/src/maud/functions.stan
+++ b/src/maud/functions.stan
@@ -65,9 +65,8 @@ functions {
     return dgrs;
   }
 
-  int check_steady_state(matrix S, vector v, vector conc){
+  int check_steady_state(vector Sv, vector conc){
     /* Relative and absolute check for steady state. */
-    vector[rows(conc)] Sv = S * v;
     real abs_thresh = 1e-8;
     vector[rows(conc)] rel_thresh = conc * 1e-3;
     int relative_check_failed = max(fabs(Sv) - rel_thresh) > 0;

--- a/src/maud/functions.stan
+++ b/src/maud/functions.stan
@@ -65,47 +65,16 @@ functions {
     return dgrs;
   }
 
-  int check_steady_state(vector[] conc_balanced,
-                        int e,
-                        vector flux,
-                        vector conc_init,
-                        real[] timepoints,
-                        vector conc_unbalanced,
-                        vector conc_enzyme_experiment,
-                        vector km,
-                        vector drain,
-                        vector kcat,
-                        vector dgrs,
-                        vector ki,
-                        vector diss_t,
-                        vector diss_r,
-                        vector transfer_constant,
-                        vector kcat_phos,
-                        vector conc_phos_experiment){
-    if ((max(fabs(conc_balanced[1]-conc_balanced[2])./conc_balanced[2]) > 0.001)){
-      print("");
-      print("Non-steady state in experiment ", e, ".");
-      print("Balanced metabolite concentration at ", timepoints[1], " seconds: ", conc_balanced[1]);
-      print("Balanced metabolite concentration at ", timepoints[2], " seconds: ", conc_balanced[2]);
-      print("flux: ", flux);
-      print("conc_init: ", conc_init);
-      print("conc_unbalanced: ", conc_unbalanced);
-      print("conc_enzyme_experiment: ", conc_enzyme_experiment);
-      print("km: ", km);
-      print("drain: ", drain);
-      print("kcat: ", kcat);
-      print("dgrs: ", dgrs);
-      print("ki: ", ki);
-      print("diss_t: ", diss_t);
-      print("diss_r: ", diss_r);
-      print("transfer_constant: ", transfer_constant);
-      print("kcat_phos: ", kcat_phos);
-      print("conc_phos_experiment: ", conc_phos_experiment);
-      return 0;
-    }
-    else {
-      return 1;
-    }
+  int check_steady_state(matrix S, vector v, vector conc){
+    /* Relative and absolute check for steady state. */
+    vector[rows(conc)] Sv = S * v;
+    real abs_thresh = 1e-8;
+    vector[rows(conc)] rel_thresh = conc * 1e-3;
+    int relative_check_failed = max(fabs(Sv) - rel_thresh) > 0;
+    int absolute_check_failed = max(fabs(Sv)) > abs_thresh;
+    if (relative_check_failed) print("Sv", Sv, " not within ", rel_thresh, " of zero.");
+    if (absolute_check_failed) print("Sv", Sv, " not within ", abs_thresh, " of zero.");
+    return (relative_check_failed || absolute_check_failed) ? 0 : 1;
   }
 
   int measure_ragged(int[,] bounds, int i){

--- a/src/maud/model.stan
+++ b/src/maud/model.stan
@@ -129,14 +129,13 @@ transformed parameters {
   vector[N_edge] dgrs = get_dgrs(S, dgf, mic_to_met, water_stoichiometry);
   for (e in 1:N_experiment){
     flux[e] = rep_vector(0, N_reaction);
-    real timepoints[2] = {timepoint, timepoint + 10};
     vector[N_enzyme] conc_enzyme_experiment = conc_enzyme[e] .* knockout[e]';
     vector[N_phosphorylation_enzymes] conc_phos_experiment = conc_phos[e] .* phos_knockout[e]';
-    vector[N_mic-N_unbalanced] conc_balanced[2] =
+    vector[N_mic-N_unbalanced] conc_balanced[1] =
       ode_bdf_tol(dbalanced_dt,
                   conc_init[e, balanced_mic_ix],
                   initial_time,
-                  timepoints,
+                  {timepoint},
                   rel_tol, 
                   abs_tol,
                   max_num_steps,
@@ -220,24 +219,24 @@ transformed parameters {
     for (j in 1:N_edge)
       flux[e, edge_to_reaction[j]] += edge_flux[j];
     }
-    if (reject_non_steady == 1 && check_steady_state(conc_balanced,
-                                                     e,
-                                                     flux[e],
-                                                     conc_init[e],
-                                                     timepoints,
-                                                     conc_unbalanced[e],
-                                                     conc_enzyme_experiment,
-                                                     km,
-                                                     drain[e],
-                                                     kcat,
-                                                     dgrs,
-                                                     ki,
-                                                     diss_t,
-                                                     diss_r,
-                                                     transfer_constant,
-                                                     kcat_phos,
-                                                     conc_phos_experiment) == 0) {
-      reject("Non-steady state in experiment ", e);
+    if (reject_non_steady == 1 && check_steady_state(S[balanced_mic_ix], flux[e], conc_balanced[1]) == 0){
+      print("Non-steady state in experiment ", e);
+      print("Balanced metabolite concentration", conc_balanced[1]);
+      print("flux: ", flux);
+      print("conc_init: ", conc_init);
+      print("conc_unbalanced: ", conc_unbalanced[e]);
+      print("conc_enzyme_experiment: ", conc_enzyme_experiment);
+      print("km: ", km);
+      print("drain: ", drain[e]);
+      print("kcat: ", kcat);
+      print("dgrs: ", dgrs);
+      print("ki: ", ki);
+      print("diss_t: ", diss_t);
+      print("diss_r: ", diss_r);
+      print("transfer_constant: ", transfer_constant);
+      print("kcat_phos: ", kcat_phos);
+      print("conc_phos_experiment: ", conc_phos_experiment);
+      reject("Rejecting");
     }
   }
 }

--- a/src/maud/model.stan
+++ b/src/maud/model.stan
@@ -218,25 +218,26 @@ transformed parameters {
                                              pi_ix_bounds);
     for (j in 1:N_edge)
       flux[e, edge_to_reaction[j]] += edge_flux[j];
-    }
-    if (reject_non_steady == 1 && check_steady_state(S[balanced_mic_ix], flux[e], conc_balanced[1]) == 0){
-      print("Non-steady state in experiment ", e);
-      print("Balanced metabolite concentration", conc_balanced[1]);
-      print("flux: ", flux);
-      print("conc_init: ", conc_init);
-      print("conc_unbalanced: ", conc_unbalanced[e]);
-      print("conc_enzyme_experiment: ", conc_enzyme_experiment);
-      print("km: ", km);
-      print("drain: ", drain[e]);
-      print("kcat: ", kcat);
-      print("dgrs: ", dgrs);
-      print("ki: ", ki);
-      print("diss_t: ", diss_t);
-      print("diss_r: ", diss_r);
-      print("transfer_constant: ", transfer_constant);
-      print("kcat_phos: ", kcat_phos);
-      print("conc_phos_experiment: ", conc_phos_experiment);
-      reject("Rejecting");
+    if (reject_non_steady == 1 &&
+        check_steady_state((S * edge_flux)[balanced_mic_ix], conc_balanced[1]) == 0){
+        print("Non-steady state in experiment ", e);
+        print("Balanced metabolite concentration", conc_balanced[1]);
+        print("flux: ", flux);
+        print("conc_init: ", conc_init);
+        print("conc_unbalanced: ", conc_unbalanced[e]);
+        print("conc_enzyme_experiment: ", conc_enzyme_experiment);
+        print("km: ", km);
+        print("drain: ", drain[e]);
+        print("kcat: ", kcat);
+        print("dgrs: ", dgrs);
+        print("ki: ", ki);
+        print("diss_t: ", diss_t);
+        print("diss_r: ", diss_r);
+        print("transfer_constant: ", transfer_constant);
+        print("kcat_phos: ", kcat_phos);
+        print("conc_phos_experiment: ", conc_phos_experiment);
+        reject("Rejecting");
+      }
     }
   }
 }

--- a/src/maud/out_of_sample_model.stan
+++ b/src/maud/out_of_sample_model.stan
@@ -105,13 +105,12 @@ generated quantities {
   // Simulation of experiments
   for (e in 1:N_experiment){
     flux[e] = rep_vector(0, N_reaction);
-    real timepoints[2] = {timepoint, timepoint + 10};
     vector[N_enzyme] conc_enzyme_experiment = conc_enzyme[e] .* knockout[e]';
     vector[N_phosphorylation_enzymes] conc_phos_experiment = conc_phos[e] .* phos_knockout[e]';
-    vector[N_mic-N_unbalanced] conc_balanced[2] = ode_bdf_tol(dbalanced_dt,
+    vector[N_mic-N_unbalanced] conc_balanced[1] = ode_bdf_tol(dbalanced_dt,
                   conc_init[e, balanced_mic_ix],
                   initial_time,
-                  timepoints,
+                  {timepoint},
                   rel_tol, 
                   abs_tol,
                   max_num_steps,
@@ -154,7 +153,7 @@ generated quantities {
                   pi_ix_long,
                   pi_ix_bounds);
     conc[e, balanced_mic_ix] = conc_balanced[1];
-    conc[e, unbalanced_mic_ix] = conc_unbalanced[e,:];
+    conc[e, unbalanced_mic_ix] = conc_unbalanced[e];
     vector[N_edge] edge_flux = get_edge_flux(conc[e],
                                              conc_enzyme_experiment,
                                              dgrs,


### PR DESCRIPTION
I changed the Stan code that checks if the system is in a steady state. Instead of doing an extra 10 second simulation, we now just calculate S times v for the balanced metabolites-in-compartments and do both a relative and absolute check for being close to zero.

The immediate reason for doing this is that the current purely relative check doesn't work for metabolites with high concentrations - they can still be accumulating even when the relative change over 10 seconds isn't very big. @ShannaraTP hit this problem in an AAA model.

Checklist:

- [ ] Updated any relevant documentation NA
- [ ] Add an adr doc if appropriate NA
- [ ] Include links to any relevant issues in the description Forgot to make an issue first, oops
- [ ] Unit tests passing
- [ ] Integration tests passing
