### PR TITLE
Variational inference and setting stanc and c++ options

### DIFF
--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -163,21 +163,9 @@ def simulate(data_path, output_dir, n):
     infd = load_infd(stanfit.runset.csv_files, mi)
     infd.to_netcdf(os.path.join(output_path, "infd.nc"))
     print("\n\nSimulated concentrations:")
-    print(
-        infd.posterior["conc"]
-        .mean(dim=["chain", "draw"])
-        .to_series()
-        .unstack()
-        .T
-    )
+    print(infd.posterior["conc"].mean(dim=["chain", "draw"]).to_series().unstack().T)
     print("\n\nSimulated fluxes:")
-    print(
-        infd.posterior["flux"]
-        .mean(dim=["chain", "draw"])
-        .to_series()
-        .unstack()
-        .T
-    )
+    print(infd.posterior["flux"].mean(dim=["chain", "draw"]).to_series().unstack().T)
     print("\n\nSimulated enzyme concentrations:")
     print(
         infd.posterior["conc_enzyme"]
@@ -192,19 +180,11 @@ def simulate(data_path, output_dir, n):
     print(infd.posterior["yconc_sim"].mean(dim=["chain", "draw"]).to_series())
     print(infd.posterior["yflux_sim"].mean(dim=["chain", "draw"]).to_series())
     print("\n\nSimulated log likelihoods:")
-    print(
-        infd.posterior["log_lik_conc"].mean(dim=["chain", "draw"]).to_series()
-    )
-    print(
-        infd.posterior["log_lik_flux"].mean(dim=["chain", "draw"]).to_series()
-    )
+    print(infd.posterior["log_lik_conc"].mean(dim=["chain", "draw"]).to_series())
+    print(infd.posterior["log_lik_flux"].mean(dim=["chain", "draw"]).to_series())
     print("\n\nSimulated allostery:")
     print(
-        infd.posterior["allostery"]
-        .mean(dim=["chain", "draw"])
-        .to_series()
-        .unstack()
-        .T
+        infd.posterior["allostery"].mean(dim=["chain", "draw"]).to_series().unstack().T
     )
     print("\n\nSimulated reversibilities:")
     print(
@@ -216,11 +196,7 @@ def simulate(data_path, output_dir, n):
     )
     print("\n\nSimulated saturation:")
     print(
-        infd.posterior["saturation"]
-        .mean(dim=["chain", "draw"])
-        .to_series()
-        .unstack()
-        .T
+        infd.posterior["saturation"].mean(dim=["chain", "draw"]).to_series().unstack().T
     )
     return output_path
 
@@ -248,12 +224,8 @@ def generate_prior_template(data_path):
     kinetic_model_path = os.path.join(data_path, config.kinetic_model_file)
     kinetic_model = parse_toml_kinetic_model(toml.load(kinetic_model_path))
     measurements_path = os.path.join(data_path, config.measurements_file)
-    biological_config_path = os.path.join(
-        data_path, config.biological_config_file
-    )
-    all_experiments = get_all_experiment_object(
-        toml.load(biological_config_path)
-    )
+    biological_config_path = os.path.join(data_path, config.biological_config_file)
+    all_experiments = get_all_experiment_object(toml.load(biological_config_path))
     raw_measurements = pd.read_csv(measurements_path)
     output_name = "prior_template.csv"
     output_path = os.path.join(data_path, output_name)
@@ -320,9 +292,7 @@ def generate_inits(data_path, chain, draw, warmup):
     default=0,
     help="Sampling draw using python indexing from start of phase",
 )
-@click.option(
-    "--warmup", default=0, help="0 if in sampling, 1 if in warmup phase"
-)
+@click.option("--warmup", default=0, help="0 if in sampling, 1 if in warmup phase")
 def generate_inits_command(data_path, chain, draw, warmup):
     """Run the generate_inits function as a click command."""
     click.echo(generate_inits(data_path, chain, draw, warmup))

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -162,16 +162,66 @@ def simulate(data_path, output_dir, n):
     stanfit = sampling.simulate(mi, samples_path, n)
     infd = load_infd(stanfit.runset.csv_files, mi)
     infd.to_netcdf(os.path.join(output_path, "infd.nc"))
-    print("\nSimulated concentrations and fluxes:")
-    print(infd.posterior["conc"].mean(dim=["chain", "draw"]).to_series())
-    print(infd.posterior["flux"].mean(dim=["chain", "draw"]).to_series())
-    print(infd.posterior["conc_enzyme"].mean(dim=["chain", "draw"]).to_series())
-    print("\nSimulated measurements:")
+    print("\n\nSimulated concentrations:")
+    print(
+        infd.posterior["conc"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated fluxes:")
+    print(
+        infd.posterior["flux"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated enzyme concentrations:")
+    print(
+        infd.posterior["conc_enzyme"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated reaction delta Gs:")
+    print(infd.posterior["dgrs"].mean(dim=["chain", "draw"]).to_series())
+    print("\n\nSimulated measurements:")
     print(infd.posterior["yconc_sim"].mean(dim=["chain", "draw"]).to_series())
     print(infd.posterior["yflux_sim"].mean(dim=["chain", "draw"]).to_series())
-    print("\nSimulated log likelihoods:")
-    print(infd.posterior["log_lik_conc"].mean(dim=["chain", "draw"]).to_series())
-    print(infd.posterior["log_lik_flux"].mean(dim=["chain", "draw"]).to_series())
+    print("\n\nSimulated log likelihoods:")
+    print(
+        infd.posterior["log_lik_conc"].mean(dim=["chain", "draw"]).to_series()
+    )
+    print(
+        infd.posterior["log_lik_flux"].mean(dim=["chain", "draw"]).to_series()
+    )
+    print("\n\nSimulated allostery:")
+    print(
+        infd.posterior["allostery"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated reversibilities:")
+    print(
+        infd.posterior["reversibility"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated saturation:")
+    print(
+        infd.posterior["saturation"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
     return output_path
 
 
@@ -198,8 +248,12 @@ def generate_prior_template(data_path):
     kinetic_model_path = os.path.join(data_path, config.kinetic_model_file)
     kinetic_model = parse_toml_kinetic_model(toml.load(kinetic_model_path))
     measurements_path = os.path.join(data_path, config.measurements_file)
-    biological_config_path = os.path.join(data_path, config.biological_config_file)
-    all_experiments = get_all_experiment_object(toml.load(biological_config_path))
+    biological_config_path = os.path.join(
+        data_path, config.biological_config_file
+    )
+    all_experiments = get_all_experiment_object(
+        toml.load(biological_config_path)
+    )
     raw_measurements = pd.read_csv(measurements_path)
     output_name = "prior_template.csv"
     output_path = os.path.join(data_path, output_name)
@@ -262,9 +316,50 @@ def generate_inits(data_path, chain, draw, warmup):
 )
 @click.option("--chain", default=0, help="Sampling chain using python indexing")
 @click.option(
-    "--draw", default=0, help="Sampling draw using python indexing from start of phase"
+    "--draw",
+    default=0,
+    help="Sampling draw using python indexing from start of phase",
 )
-@click.option("--warmup", default=0, help="0 if in sampling, 1 if in warmup phase")
+@click.option(
+    "--warmup", default=0, help="0 if in sampling, 1 if in warmup phase"
+)
 def generate_inits_command(data_path, chain, draw, warmup):
     """Run the generate_inits function as a click command."""
     click.echo(generate_inits(data_path, chain, draw, warmup))
+
+
+def variational(data_path, output_dir):
+    """Generate MCMC samples given a user input directory.
+
+    This function creates a new directory in output_dir with a name starting
+    with "maud_output". It first copies the directory at data_path into the new
+    this directory at new_dir/user_input, then runs the sampling.sample
+    function to write samples in new_dir/samples. Finally it prints the results
+    of cmdstanpy's diagnose and summary methods.
+
+    """
+    mi = load_maud_input(data_path, mode="sample")
+    now = datetime.now().strftime("%Y%m%d%H%M%S")
+    output_name = f"maud_output_vi-{mi.config.name}-{now}"
+    output_path = os.path.join(output_dir, output_name)
+    samples_path = os.path.join(output_path, "samples")
+    ui_dir = os.path.join(output_path, "user_input")
+    print("Creating output directory: " + output_path)
+    os.mkdir(output_path)
+    os.mkdir(samples_path)
+    print(f"Copying user input from {data_path} to {ui_dir}")
+    shutil.copytree(data_path, ui_dir)
+    sampling.variational(mi, samples_path)
+    return output_path
+
+
+@cli.command("variational")
+@click.option("--output_dir", default=".", help="Where to save Maud's output")
+@click.argument(
+    "data_path",
+    type=click.Path(exists=True, dir_okay=True, file_okay=False),
+    default=get_example_path(RELATIVE_PATH_EXAMPLE),
+)
+def variational_command(data_path, output_dir):
+    """Run the sample function as a click command."""
+    click.echo(variational(data_path, output_dir))

--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -233,7 +233,9 @@ class KineticModel:
         self.reactions = reactions
         self.compartments = compartments
         self.mics = mics
-        self.phosphorylation = phosphorylation if phosphorylation is not None else []
+        self.phosphorylation = (
+            phosphorylation if phosphorylation is not None else []
+        )
 
 
 @dataclass
@@ -308,7 +310,9 @@ class MultiVariateNormalPrior1d:
         try:
             np.linalg.cholesky(self.covariance_matrix.values)
         except LinAlgError as e:
-            raise ValueError("Covariance matrix is not positive definite") from e
+            raise ValueError(
+                "Covariance matrix is not positive definite"
+            ) from e
 
 
 @dataclass
@@ -380,6 +384,9 @@ class MaudConfig:
     :param reject_non_steady: Reject draws if a non-steady state is encountered.
     :param ode_config: Configuration for Stan's ode solver.
     :param cmdstanpy_config: Arguments to cmdstanpy.CmdStanModel.sample.
+    :param stanc_options: Valid choices for CmdStanModel argument `stanc_options`.
+    :param cpp_options: Valid choices for CmdStanModel `cpp_options`.
+    :param variational_options: Arguments for CmdStanModel.variational.
     :param user_inits_file: path to a csv file of initial values.
     :param dgf_mean_file: path to a csv file of formation energy means.
     :param dgf_covariance_file: path to a csv file of formation energy covariances.
@@ -396,6 +403,9 @@ class MaudConfig:
     reject_non_steady: bool
     ode_config: dict
     cmdstanpy_config: dict
+    stanc_options: Optional[dict]
+    cpp_options: Optional[dict]
+    variational_options: Optional[dict]
     user_inits_file: Optional[str]
     dgf_mean_file: Optional[str]
     dgf_covariance_file: Optional[str]

--- a/src/maud/data_model.py
+++ b/src/maud/data_model.py
@@ -233,9 +233,7 @@ class KineticModel:
         self.reactions = reactions
         self.compartments = compartments
         self.mics = mics
-        self.phosphorylation = (
-            phosphorylation if phosphorylation is not None else []
-        )
+        self.phosphorylation = phosphorylation if phosphorylation is not None else []
 
 
 @dataclass
@@ -310,9 +308,7 @@ class MultiVariateNormalPrior1d:
         try:
             np.linalg.cholesky(self.covariance_matrix.values)
         except LinAlgError as e:
-            raise ValueError(
-                "Covariance matrix is not positive definite"
-            ) from e
+            raise ValueError("Covariance matrix is not positive definite") from e
 
 
 @dataclass

--- a/src/maud/io.py
+++ b/src/maud/io.py
@@ -672,6 +672,15 @@ def parse_config(raw):
     reject_non_steady: bool = (
         raw["reject_non_steady"] if "reject_non_steady" in raw.keys() else True
     )
+    stanc_options: Optional[dict] = (
+        raw["stanc_options"] if "stanc_options" in raw.keys() else None
+    )
+    cpp_options: Optional[dict] = (
+        raw["cpp_options"] if "cpp_options" in raw.keys() else None
+    )
+    variational_options: Optional[dict] = (
+        raw["variational_options"] if "variational_options" in raw.keys() else None
+    )
     steady_state_threshold_abs: float = (
         raw["steady_state_threshold_abs"]
         if "steady_state_threshold_abs" in raw.keys()
@@ -693,6 +702,9 @@ def parse_config(raw):
         reject_non_steady=reject_non_steady,
         ode_config={**DEFAULT_ODE_CONFIG, **raw["ode_config"]},
         cmdstanpy_config=raw["cmdstanpy_config"],
+        stanc_options=stanc_options,
+        cpp_options=cpp_options,
+        variational_options=variational_options,
         user_inits_file=user_inits_file,
         dgf_mean_file=dgf_mean_file,
         dgf_covariance_file=dgf_covariance_file,

--- a/src/maud/model.stan
+++ b/src/maud/model.stan
@@ -97,6 +97,7 @@ transformed data {
   matrix[N_experiment, N_enzyme] knockout = rep_matrix(1, N_experiment, N_enzyme) - is_knockout;
   matrix[N_experiment, N_phosphorylation_enzymes] phos_knockout =
     rep_matrix(1, N_experiment, N_phosphorylation_enzymes) - is_phos_knockout;
+  matrix[N_metabolite, N_metabolite] prior_cov_dgf_chol = cholesky_decompose(prior_cov_dgf);
 }
 parameters {
   vector[N_metabolite] dgf;
@@ -250,7 +251,7 @@ model {
   log_diss_t_z ~ std_normal();
   log_diss_r_z ~ std_normal();
   log_transfer_constant_z ~ std_normal();
-  dgf ~ multi_normal(prior_loc_dgf, prior_cov_dgf);
+  dgf ~ multi_normal_cholesky(prior_loc_dgf, prior_cov_dgf_chol);
   log_kcat_phos_z ~ std_normal();
   for (ex in 1:N_experiment){
     log_conc_unbalanced_z[ex] ~ std_normal();


### PR DESCRIPTION
This change adds a new command `maud variational` which runs variational inference via the cmdstanpy method `CmdStanModel.variational`. Arguments can be configured in the config file in the table `variational_options`.

Variational inference could potentially be useful for getting results quicker than MCMC when we know it is sure to work, and also for finding a good parameter configuration to initialise the MCMC.

I also added the possibility to customise how the underlying Stan model is compiled to c++, through the CmdStanModel instantiation arguments `stanc_options` and `cpp_options`. These each get their own optional tables in the config file. Lists of possible options can be found [here](https://mc-stan.org/docs/2_29/stan-users-guide/stanc-args.html) and [here](https://github.com/stan-dev/math/blob/01dd2e7487236880bfc7282119d1355fdfd9dc48/make/compiler_flags). It is handy to be able to tweak these options so that we can use custom C++ code, add some compiler optimisations for performance and improve our Stan code using the pedantic mode.


Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [ ] Unit tests passing
- [ ] Integration tests passing
