### PR TITLE
Feat: Workflow for releasing new versions of maud and setup.cfg fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release Maud
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.9]
+      fail-fast: false
+  steps:
+    - name: Check out source code
+      uses: actions/checkout@v2
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        python-version: ${{ matrix.python-version }}
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: |
+          Changes in this Release
+        draft: false
+        prerelease: false
+
+  deploy:
+    needs: release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.9]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload --repository testpypi dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,21 +15,21 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.9]
       fail-fast: false
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Create Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        python-version: ${{ matrix.python-version }}
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        body: |
-          Changes in this Release
-        draft: false
-        prerelease: false
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          python-version: ${{ matrix.python-version }}
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Changes in this Release
+          draft: false
+          prerelease: false
 
   deploy:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,37 +8,8 @@ on:
 
 jobs:
   release:
-    name: Create Release
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.9]
-      fail-fast: false
-    steps:
-      - name: Check out source code
-        uses: actions/checkout@v2
-      - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          python-version: ${{ matrix.python-version }}
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Changes in this Release
-          draft: false
-          prerelease: false
-
-  deploy:
-    needs: release
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.9]
-      fail-fast: false
+    runs-on: ubuntu-latest
+    python-version: 3.9
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
@@ -49,10 +20,20 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Build and publish
+    - name: Build package
+      run: python setup.py sdist bdist_wheel
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Create GitHub release
+      uses: actions/create-release@v1
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+        # This token is set by gh actions
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        draft: false
+        prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.9]
       fail-fast: false
   steps:
-    - name: Check out source code
+    - name: Checkout
       uses: actions/checkout@v2
     - name: Create Release
       uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    python-version: 3.9
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.rst
+++ b/README.rst
@@ -36,12 +36,12 @@ First create a fresh Python 3.7 virtual environment and then activate it:
     python3.7 -m virtualenv maud_venv  # choose any name you like!
     source maud_venv/bin/activate
 
-To install the latest Maud and its python dependencies to your new virtual
-environment from the latest master branch, run this command:
+To install Maud and its python dependencies to your new virtual environment, run
+this command:
 
 .. code-block:: console
 
-    pip install https://github.com/biosustain/Maud/archive/master.zip
+    pip install maud-metabolic-models
 
 Cmdstanpy depends on `cmdstan <https://github.com/stan-dev/cmdstan>`_, 
 which in turn requires a c++ toolchain. Fortunately, cmdstanpy comes with

--- a/docs/usage/contributing.rst
+++ b/docs/usage/contributing.rst
@@ -82,7 +82,8 @@ Releasing versions
 ==================
 
 To release a new version of Maud, edit the field :code:`version` in the file
-:code:`setup.cfg`, then make a pull request with this change.
+:code:`setup.cfg`, then make a pull request with this change. The version name
+should start with a letter v, e.g. :code:`v0.2.1`,
 
 Once the changes are merged into the :code:`origin/master` branch, add a tag
 with the new version number to your local :code:`master` branch, for example
@@ -90,10 +91,10 @@ like this:
 
 .. code:: bash
 
-          git tag 0.2.1
+          git tag v0.2.1
 
 Now push the new tag to github:
  
 .. code:: bash
 
-          git push origin "0.2.1"
+          git push origin "v0.2.1"

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -13,11 +13,11 @@ then activate it, run the following commands:
     source maud_venv/bin/activate
 
 To install the latest Maud and its python dependencies to your new virtual
-environment from the latest master branch, run this command:
+environment, run this command:
 
 .. code-block:: console
 
-    pip install https://github.com/biosustain/Maud/archive/master.zip
+    pip install maud-metabolic-models
 
 Cmdstanpy depends on `cmdstan <https://github.com/stan-dev/cmdstan>`, which
 in turn requires a c++ toolchain. Fortunately, cmdstanpy comes with commands 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,15 @@
 [metadata]
-name = maud
+name = maud-metabolic-models
 url = https://github.com/biosustain/Maud
-download_url = https://pypi.org/project/maud/
+download_url = https://pypi.org/project/maud-metabolic-models/
 author = Novo Nordisk Foundation Center for Biosustainability, Technical University of Denmark
 author_email = tedgro@dtu.dk
+version = 0.3.2
 # Please consult https://pypi.org/classifiers/ for a full list.
-version = 0.3.1
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Science/Research
-    License :: OSI Approved :: GNU General Public License version 3
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Natural Language :: English
     Operating System :: MacOS :: MacOS X
     Operating System :: Microsoft :: Windows :: Windows 10
@@ -36,7 +36,7 @@ install_requires =
     matplotlib
     jinja2
     toml
-    cmdstanpy@git+https://github.com/stan-dev/cmdstanpy.git@develop
+    cmdstanpy == 1.0.3
     click
     depinfo == 1.7.0
     tqdm


### PR DESCRIPTION
This change adds a github workflow that should create a new release of maud on pypi every time a git tag starting with 'v' is pushed. This fixes issue #27.

I have done the necessary clicking and typing to put maud on PyPI under the name 'maud-metabolic-models' (`pip install maud-metabolic-models` now works!), but I haven't tested the github action yet as I have no idea how to do that! I'll have a go when this pr is merged.

Checklist:

- [x] Updated any relevant documentation
- [ ] Add an adr doc if appropriate NA
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [ ] Integration tests passing NA
