### PR TITLE
Bug: Fix unbalanced mic concentration stan variable and validate

### DIFF
--- a/scripts/export-yaml.py
+++ b/scripts/export-yaml.py
@@ -245,7 +245,10 @@ def main():
             tmp_dg = 0
             for mic_id, stoic in rxn.stoichiometry.items():
                 met_id = next(
-                    filter(lambda mic: mic.id == mic_id, mi.kinetic_model.mics)
+                    filter(
+                        lambda mic: mic.id == mic_id,  # noqa: B023
+                        mi.kinetic_model.mics,
+                    )
                 ).metabolite_id
                 met_dgf = list(dgfs[dgfs["metabolite_id"] == met_id]["value"])[
                     0

--- a/src/maud/getting_stan_variables.py
+++ b/src/maud/getting_stan_variables.py
@@ -114,7 +114,16 @@ def get_stan_variable_set(kmod: KineticModel, ms: MeasurementSet):
     drain_ids = [
         d.id for d in kmod.reactions if d.mechanism == ReactionMechanism.DRAIN
     ]
-    unbalanced_mics = [m.id for m in kmod.mics if not m.balanced]
+    unbalanced_mic_ids, unbalanced_mic_mets, unbalanced_mic_cpts = map(
+        list,
+        zip(
+            *[
+                [m.id, m.metabolite_id, m.compartment_id]
+                for m in kmod.mics
+                if not m.balanced
+            ]
+        ),
+    )
     return StanVariableSet(
         dgf=Dgf(ids=[metabolite_ids]),
         km=Km(ids=[km_ids], split_ids=[km_enzs, km_mets, km_cpts]),
@@ -127,7 +136,13 @@ def get_stan_variable_set(kmod: KineticModel, ms: MeasurementSet):
         kcat_pme=KcatPme(ids=[phos_modifying_enzymes]),
         drain=Drain(ids=[exp_ids, drain_ids]),
         conc_enzyme=ConcEnzyme(ids=[exp_ids, enzyme_ids]),
-        conc_unbalanced=ConcUnbalanced(ids=[exp_ids, unbalanced_mics]),
+        conc_unbalanced=ConcUnbalanced(
+            ids=[exp_ids, unbalanced_mic_ids],
+            split_ids=[
+                [exp_ids],
+                [unbalanced_mic_mets, unbalanced_mic_cpts],
+            ],
+        ),
         conc_pme=ConcPme(ids=[exp_ids, phos_modifying_enzymes]),
         psi=Psi(ids=[exp_ids]),
     )

--- a/src/maud/parsing_measurements.py
+++ b/src/maud/parsing_measurements.py
@@ -24,7 +24,7 @@ def parse_measurement_set(
     ]
     y = {
         mt: raw_measurement_table.loc[
-            lambda df: df["measurement_type"] == mt.value
+            lambda df: df["measurement_type"] == mt.value  # noqa: B023
         ]
         for mt in MeasurementType
     }


### PR DESCRIPTION
Jorge found a [problem](https://github.com/biosustain/maudtools/pull/15#pullrequestreview-1042997760) in maudtools that I think is caused by an upstream bug in Maud: the `ConcUnbalanced` Stan variable should have existing `split_ids` because it is partly identified by metabolite-in-compartments, which in turn have split ids.

This change fixes `ConcUnbalanced` and also adds a new validation to check that any Stan variable with non-trivial id components has split ids.

Checklist:

- [ ] Updated any relevant documentation NA
- [ ] Add an adr doc if appropriate NA
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [x] Integration tests passing
