### PR TITLE
Customise starting ode state vector

### DIFF
--- a/src/maud/data_model/maud_config.py
+++ b/src/maud/data_model/maud_config.py
@@ -1,5 +1,5 @@
 """Provides dataclass MaudConfig."""
-from typing import Optional, List
+from typing import List, Optional
 
 from pydantic import Field, root_validator
 from pydantic.dataclasses import dataclass

--- a/src/maud/data_model/maud_config.py
+++ b/src/maud/data_model/maud_config.py
@@ -1,5 +1,5 @@
 """Provides dataclass MaudConfig."""
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import Field, root_validator
 from pydantic.dataclasses import dataclass
@@ -33,6 +33,7 @@ class MaudConfig:
     :param user_inits_file: path to a csv file of initial values.
     :param dgf_mean_file: path to a csv file of formation energy means.
     :param dgf_covariance_file: path to a csv file of formation energy covariances.
+    :param conc_init: Optional per-experiment list of starting metabolite concentrations
     :param steady_state_threshold_abs: absolute threshold for Sv=0 be at steady state
     :param steady_state_threshold_rel: relative threshold for Sv=0 be at steady state
     :param: drain_small_conc_corrector: number for correcting small conc drains
@@ -52,6 +53,7 @@ class MaudConfig:
     user_inits_file: Optional[str] = None
     dgf_mean_file: Optional[str] = None
     dgf_covariance_file: Optional[str] = None
+    conc_init: Optional[List[List[float]]] = None
     ode_config: ODEConfig = ODEConfig()
     reject_non_steady: bool = True
     steady_state_threshold_abs: float = 1e-8

--- a/src/maud/getting_stan_inputs.py
+++ b/src/maud/getting_stan_inputs.py
@@ -453,7 +453,9 @@ def get_stan_inputs(
         # configuration
         conc_init=get_conc_init(
             ms, kinetic_model, priors, config, mode="train"
-        ),
+        )
+        if config.conc_init is None
+        else StanData("conc_init", config.conc_init),
         likelihood=StanData("likelihood", int(config.likelihood)),
         drain_small_conc_corrector=StanData(
             "drain_small_conc_corrector",
@@ -573,7 +575,9 @@ def get_stan_inputs(
             # configuration
             conc_init=get_conc_init(
                 ms, kinetic_model, priors, config, mode="test"
-            ),
+            )
+            if config.conc_init is None
+            else StanData("conc_init", config.conc_init),
             likelihood=StanData("likelihood", int(config.likelihood)),
             drain_small_conc_corrector=StanData(
                 "drain_small_conc_corrector",


### PR DESCRIPTION
This is a possible easy performance win that we haven't yet explored properly. 

We currently choose 0.01 or the measured value for each balanced mic and hope to get to the steady state solution by simulating from there for a while. This change lets you optionally set your own starting state vector. Potentially this should make it possible to get to a steady state more easily. I tried it on the linear test model and was able to find a better starting guess using `maud simulate`.

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [ ] Unit tests passing
- [ ] Integration tests passing
