### PR TITLE
chore: pin arviz and pydantic deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ zip_safe = True
 include_package_data=True
 install_requires =
     pip >= 20
-    arviz
+    arviz == 0.12.1
+		netCDF4 == 1.5.8
     numpy
     scipy
     sympy
@@ -41,7 +42,7 @@ install_requires =
     depinfo == 1.7.0
     tqdm
     plotnine
-    pydantic >= 1.9.0
+    pydantic == 1.9.0
     seaborn
 python_requires = >=3.7
 tests_require =


### PR DESCRIPTION
### Description

Pydantic 1.10 is making the type validation fail for `split_ids` at least for kcats, whereas it worked fine for pydantic 1.9.
A dependency (netCDF4) of arviz is also making it fail.

### Implementation 

I have pinned netCDF4, arviz and pydantic.

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [] Include links to any relevant issues in the description
- [x] Unit tests passing
- [x] Integration tests passing
