### PR TITLE
including split ids

### DIFF
--- a/src/maud/data_model/stan_variable_set.py
+++ b/src/maud/data_model/stan_variable_set.py
@@ -148,10 +148,10 @@ class Ki(StanVariable):
 class Dgf(StanVariable):
     """Stan variable representing a model's standard formation energies."""
 
-    def __init__(self, ids):
+    def __init__(self, ids, split_ids):
         self.name = "dgf"
         self.ids = ids
-        self.split_ids = None
+        self.split_ids = split_ids
         self.shape_names = ["N_metabolite"]
         self.id_components = [[IdComponent.METABOLITE]]
         self.non_negative = False
@@ -194,12 +194,12 @@ class DissociationConstant(StanVariable):
 class TransferConstant(StanVariable):
     """Stan variable representing a model's transfer constants."""
 
-    def __init__(self, ids):
+    def __init__(self, ids, split_ids):
         self.name = "transfer_constant"
         self.ids = ids
         self.shape_names = ["N_ae"]
         self.id_components = [[IdComponent.ENZYME]]
-        self.split_ids = None
+        self.split_ids = split_ids
         self.non_negative = True
         self.default_loc = 0.5
         self.default_scale = 1
@@ -209,11 +209,11 @@ class TransferConstant(StanVariable):
 class KcatPme(StanVariable):
     """Stan variable representing Kcats of phosphorylation modifying enzymes."""
 
-    def __init__(self, ids):
+    def __init__(self, ids, split_ids):
         self.name = "kcat_pme"
         self.ids = ids
         self.shape_names = ["N_pme"]
-        self.split_ids = None
+        self.split_ids = split_ids
         self.id_components = [[IdComponent.PHOSPHORYLATION_MODIFYING_ENZYME]]
         self.non_negative = True
         self.default_loc = 0.5
@@ -224,12 +224,12 @@ class KcatPme(StanVariable):
 class Drain(StanVariable):
     """Stan variable representing a model's drain parameters."""
 
-    def __init__(self, ids):
+    def __init__(self, ids, split_ids):
         self.name = "drain"
         self.ids = ids
         self.shape_names = ["N_experiment", "N_drain"]
         self.id_components = [[IdComponent.EXPERIMENT], [IdComponent.REACTION]]
-        self.split_ids = None
+        self.split_ids = split_ids
         self.non_negative = False
         self.default_loc = 0
         self.default_scale = 1
@@ -239,12 +239,12 @@ class Drain(StanVariable):
 class ConcEnzyme(StanVariable):
     """Stan variable representing a model's enzyme concentrations."""
 
-    def __init__(self, ids):
+    def __init__(self, ids, split_ids):
         self.name = "conc_enzyme"
         self.ids = ids
         self.shape_names = ["N_experimeent", "N_enzyme"]
         self.id_components = [[IdComponent.EXPERIMENT], [IdComponent.ENZYME]]
-        self.split_ids = None
+        self.split_ids = split_ids
         self.non_negative = True
         self.default_loc = 0.1
         self.default_scale = 2.0
@@ -274,11 +274,11 @@ class ConcUnbalanced(StanVariable):
 class ConcPme(StanVariable):
     """Stan variable representing a model's pme concentrations."""
 
-    def __init__(self, ids):
+    def __init__(self, ids, split_ids):
         self.name = "conc_pme"
         self.ids = ids
         self.shape_names = ["N_experiment", "N_pme"]
-        self.split_ids = None
+        self.split_ids = split_ids
         self.id_components = [
             [IdComponent.EXPERIMENT],
             [IdComponent.PHOSPHORYLATION_MODIFYING_ENZYME],
@@ -292,11 +292,11 @@ class ConcPme(StanVariable):
 class Psi(StanVariable):
     """Stan variable representing per-experiment membrane potentials."""
 
-    def __init__(self, ids):
+    def __init__(self, ids, split_ids):
         self.name = "psi"
         self.ids = ids
         self.shape_names = ["N_experiment"]
-        self.split_ids = None
+        self.split_ids = split_ids
         self.id_components = [[IdComponent.EXPERIMENT]]
         self.non_negative = False
         self.default_loc = 0

--- a/src/maud/getting_stan_variables.py
+++ b/src/maud/getting_stan_variables.py
@@ -139,12 +139,14 @@ def get_stan_variable_set(kmod: KineticModel, ms: MeasurementSet):
         ),
         transfer_constant=TransferConstant(
             ids=[allosteric_enzyme_ids], split_ids=[allosteric_enzyme_ids]
-            ),
+        ),
         kcat_pme=KcatPme(
             ids=[phos_modifying_enzymes], split_ids=[phos_modifying_enzymes]
-            ),
+        ),
         drain=Drain(ids=[exp_ids, drain_ids], split_ids=[exp_ids, drain_ids]),
-        conc_enzyme=ConcEnzyme(ids=[exp_ids, enzyme_ids], split_ids=[exp_ids, enzyme_ids]),
+        conc_enzyme=ConcEnzyme(
+            ids=[exp_ids, enzyme_ids], split_ids=[exp_ids, enzyme_ids]
+        ),
         conc_unbalanced=ConcUnbalanced(
             ids=[exp_ids, unbalanced_mic_ids],
             split_ids=[
@@ -154,7 +156,7 @@ def get_stan_variable_set(kmod: KineticModel, ms: MeasurementSet):
         ),
         conc_pme=ConcPme(
             ids=[exp_ids, phos_modifying_enzymes],
-            split_ids=[exp_ids, phos_modifying_enzymes]
-            ),
+            split_ids=[exp_ids, phos_modifying_enzymes],
+        ),
         psi=Psi(ids=[exp_ids], split_ids=[exp_ids]),
     )

--- a/src/maud/getting_stan_variables.py
+++ b/src/maud/getting_stan_variables.py
@@ -130,17 +130,21 @@ def get_stan_variable_set(kmod: KineticModel, ms: MeasurementSet):
         ),
     )
     return StanVariableSet(
-        dgf=Dgf(ids=[metabolite_ids]),
+        dgf=Dgf(ids=[metabolite_ids], split_ids=[metabolite_ids]),
         km=Km(ids=[km_ids], split_ids=[km_enzs, km_mets, km_cpts]),
         kcat=Kcat(ids=[kcat_ids], split_ids=[kcat_enzs, kcat_rxns]),
         ki=Ki(ids=[ci_ids], split_ids=[ci_enzs, ci_rxns, ci_mets, ci_cpts]),
         dissociation_constant=DissociationConstant(
             ids=[dc_ids], split_ids=[dc_enzs, dc_mets, dc_cpts]
         ),
-        transfer_constant=TransferConstant(ids=[allosteric_enzyme_ids]),
-        kcat_pme=KcatPme(ids=[phos_modifying_enzymes]),
-        drain=Drain(ids=[exp_ids, drain_ids]),
-        conc_enzyme=ConcEnzyme(ids=[exp_ids, enzyme_ids]),
+        transfer_constant=TransferConstant(
+            ids=[allosteric_enzyme_ids], split_ids=[allosteric_enzyme_ids]
+            ),
+        kcat_pme=KcatPme(
+            ids=[phos_modifying_enzymes], split_ids=[phos_modifying_enzymes]
+            ),
+        drain=Drain(ids=[exp_ids, drain_ids], split_ids=[exp_ids, drain_ids]),
+        conc_enzyme=ConcEnzyme(ids=[exp_ids, enzyme_ids], split_ids=[exp_ids, enzyme_ids]),
         conc_unbalanced=ConcUnbalanced(
             ids=[exp_ids, unbalanced_mic_ids],
             split_ids=[
@@ -148,6 +152,9 @@ def get_stan_variable_set(kmod: KineticModel, ms: MeasurementSet):
                 [unbalanced_mic_mets, unbalanced_mic_cpts],
             ],
         ),
-        conc_pme=ConcPme(ids=[exp_ids, phos_modifying_enzymes]),
-        psi=Psi(ids=[exp_ids]),
+        conc_pme=ConcPme(
+            ids=[exp_ids, phos_modifying_enzymes],
+            split_ids=[exp_ids, phos_modifying_enzymes]
+            ),
+        psi=Psi(ids=[exp_ids], split_ids=[exp_ids]),
     )


### PR DESCRIPTION
# Summary
Indexing parameters in Maud will be more consistent as we only need to refer to the id_components and split_ids.

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [ ] Unit tests passing
- [ ] Integration tests passing
