### PR TITLE
chore: change split ids in conc_unbalanced

### DIFF
--- a/src/maud/data_model/stan_variable_set.py
+++ b/src/maud/data_model/stan_variable_set.py
@@ -263,7 +263,8 @@ class ConcUnbalanced(StanVariable):
         self.split_ids = split_ids
         self.id_components = [
             [IdComponent.EXPERIMENT],
-            [IdComponent.METABOLITE, IdComponent.COMPARTMENT],
+            [IdComponent.METABOLITE],
+            [IdComponent.COMPARTMENT],
         ]
         self.non_negative = True
         self.default_loc = 0.1

--- a/src/maud/getting_stan_variables.py
+++ b/src/maud/getting_stan_variables.py
@@ -150,8 +150,7 @@ def get_stan_variable_set(kmod: KineticModel, ms: MeasurementSet):
         conc_unbalanced=ConcUnbalanced(
             ids=[exp_ids, unbalanced_mic_ids],
             split_ids=[
-                [exp_ids],
-                [unbalanced_mic_mets, unbalanced_mic_cpts],
+                [exp_ids, unbalanced_mic_mets, unbalanced_mic_cpts],
             ],
         ),
         conc_pme=ConcPme(


### PR DESCRIPTION
#Summary:
Noticed that split ids for unbalanced concentrations weren’t using elementary components and changed them back to metabolites and compartments

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [ ] Unit tests passing
- [ ] Integration tests passing
