### PR TITLE
Feat: example output

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ url = https://github.com/biosustain/Maud
 download_url = https://pypi.org/project/maud-metabolic-models/
 author = Novo Nordisk Foundation Center for Biosustainability, Technical University of Denmark
 author_email = tedgro@dtu.dk
-version = 0.4.0.1
+version = 0.4.0.2
 # Please consult https://pypi.org/classifiers/ for a full list.
 classifiers =
     Development Status :: 2 - Pre-Alpha

--- a/src/maud/data/example_outputs/linear/user_input/config.toml
+++ b/src/maud/data/example_outputs/linear/user_input/config.toml
@@ -1,0 +1,21 @@
+name = "linear"
+kinetic_model_file = "kinetic_model.toml"
+priors_file = "priors.toml"
+experiments_file = "experiments.toml"
+likelihood = true
+steady_state_threshold_abs = 1e-6
+
+[cmdstanpy_config]
+refresh = 1
+iter_warmup = 300
+iter_sampling = 300
+chains = 4
+save_warmup = true
+seed = 1234
+
+[ode_config]
+abs_tol = 1e-5
+rel_tol = 1e-5
+max_num_steps = 1e6
+timepoint = 1e3
+

--- a/src/maud/data/example_outputs/linear/user_input/experiments.toml
+++ b/src/maud/data/example_outputs/linear/user_input/experiments.toml
@@ -1,0 +1,30 @@
+[[experiment]]
+id = "condition1"
+is_train = true
+is_test = true
+temperature = 299.0
+measurements = [
+  {target_type = "mic", metabolite = "M1", compartment = "c", value = 0.59, error_scale = 0.1},
+  {target_type = "mic", metabolite = "M2", compartment = "c", value = 0.38, error_scale = 0.1},
+  {target_type = "mic", metabolite = "M1", compartment = "e", value = 1.09, error_scale = 0.05},
+  {target_type = "mic", metabolite = "M2", compartment = "e", value = 1.05, error_scale = 0.05},
+  {target_type = "flux", reaction = "r3", value = 0.19, error_scale = 0.1},
+  {target_type = "enzyme", enzyme = "r1", value = 1.5, error_scale = 0.1},
+  {target_type = "enzyme", enzyme = "r2", value = 1.5, error_scale = 0.1},
+  {target_type = "enzyme", enzyme = "r3", value = 1.5, error_scale = 0.1},
+]
+
+[[experiment]]
+id = "condition2"
+is_train = true
+is_test = true
+measurements = [
+  {target_type = "mic", metabolite = "M1", compartment = "c", value = 0.54, error_scale = 0.1},
+  {target_type = "mic", metabolite = "M2", compartment = "c", value = 0.38, error_scale = 0.1},
+  {target_type = "mic", metabolite = "M1", compartment = "e", value = 1.12, error_scale = 0.05},
+  {target_type = "mic", metabolite = "M2", compartment = "e", value = 1.14, error_scale = 0.05},
+  {target_type = "flux", reaction = "r3", value = 0.39, error_scale = 0.1},
+  {target_type = "enzyme", enzyme = "r1", value = 1.5, error_scale = 0.1},
+  {target_type = "enzyme", enzyme = "r2", value = 1.5, error_scale = 0.1},
+  {target_type = "enzyme", enzyme = "r3", value = 1.5, error_scale = 0.1},
+]

--- a/src/maud/data/example_outputs/linear/user_input/kinetic_model.toml
+++ b/src/maud/data/example_outputs/linear/user_input/kinetic_model.toml
@@ -1,0 +1,66 @@
+name = "Example kinetic model"
+
+compartment = [
+  {id = 'c', name = 'cytosol', volume = 1},
+  {id = 'e', name = 'external', volume = 1},
+]
+
+metabolite = [
+  {id = "M1", name = "Metabolite number 1"},
+  {id = "M2", name = "Metabolite number 2"},
+]
+
+enzyme = [
+  {id = "r1", name = "r1ase", subunits = 1},
+  {id = "r2", name = "r2ase", subunits = 1},
+  {id = "r3", name = "r3ase", subunits = 1},
+]
+
+metabolite_in_compartment = [
+  {metabolite_id = "M1", compartment_id = "e", balanced = false},
+  {metabolite_id = "M1", compartment_id = "c", balanced = true},
+  {metabolite_id = "M2", compartment_id = "c", balanced = true},
+  {metabolite_id = "M2", compartment_id = "e", balanced = false},
+]
+enzyme_reaction = [
+  {enzyme_id = "r1", reaction_id = "r1"},
+  {enzyme_id = "r2", reaction_id = "r2"},
+  {enzyme_id = "r3", reaction_id = "r3"},
+]
+
+[[reaction]]
+id = "r1"
+name = "Reaction number 1"
+mechanism = "reversible_michaelis_menten"
+stoichiometry = { M1_e = -1, M1_c = 1}
+
+[[reaction]]
+id = "r2"
+name = "Reaction number 2"
+mechanism = "irreversible_michaelis_menten"
+stoichiometry = { M1_c = -1, M2_c = 1}
+
+[[reaction]]
+id = "r3"
+name = "Reaction number 3"
+mechanism = "reversible_michaelis_menten"
+stoichiometry = { M2_c = -1, M2_e = 1}
+transported_charge = 1
+
+[[allostery]]
+enzyme_id = "r1"
+metabolite_id = "M2"
+compartment_id = "c"
+modification_type = "activation"
+
+[[allostery]]
+enzyme_id = "r2"
+metabolite_id = "M1"
+compartment_id = "c"
+modification_type = "inhibition"
+
+[[competitive_inhibition]]
+enzyme_id = "r2"
+reaction_id = "r2"
+metabolite_id = "M1"
+compartment_id = "c"

--- a/src/maud/data/example_outputs/linear/user_input/parameters.toml
+++ b/src/maud/data/example_outputs/linear/user_input/parameters.toml
@@ -1,0 +1,37 @@
+kcat = [
+  {exploc = 1, scale = 0.6, reaction = "r1", enzyme = "r1"},
+  {exploc = 1, scale = 0.6, reaction = "r2", enzyme = "r2"},
+  {exploc = 1, scale = 0.6, reaction = "r3", enzyme = "r3"},
+]
+
+km = [
+  {exploc = 1, scale = 0.6, metabolite = "M1", compartment = "e", enzyme = "r1"},
+  {exploc = 1, scale = 0.6, metabolite = "M1", compartment = "c", enzyme = "r1"},
+  {exploc = 1, scale = 0.6, metabolite = "M1", compartment = "c", enzyme = "r2"},
+  {exploc = 1, scale = 0.6, metabolite = "M2", compartment = "c", enzyme = "r3"},
+  {exploc = 1, scale = 0.6, metabolite = "M2", compartment = "e", enzyme = "r3"},
+]
+
+transfer_constant = [
+  {exploc = 1, scale = 0.6, enzyme = "r1"},
+  {exploc = 1, scale = 0.6, enzyme = "r2"},
+]
+
+dissociation_constant = [
+  {exploc = 1, scale = 0.6, enzyme = "r1", metabolite = "M2", compartment = "c", modification_type = "activation"},
+  {exploc = 1, scale = 0.6, enzyme = "r2", metabolite = "M1", compartment = "c", modification_type = "inhibition"},
+]
+
+dgf = [
+  {location = -1, metabolite = "M1", scale = 0.05},
+  {location = -2, metabolite = "M2", scale = 0.05},
+]
+
+psi = [
+  {location = -0.95, scale = 0.2, experiment = "condition1"},
+  {location = -0.95, scale = 0.2, experiment = "condition2"},
+]
+
+ki = [
+  {exploc = 1, scale = 0.6, enzyme = "r2", reaction = "r2", metabolite = "M1", compartment = "c"},
+]

--- a/src/maud/data/example_outputs/linear/user_input/priors.toml
+++ b/src/maud/data/example_outputs/linear/user_input/priors.toml
@@ -1,0 +1,37 @@
+kcat = [
+  {exploc = 1, scale = 0.6, reaction = "r1", enzyme = "r1"},
+  {exploc = 1, scale = 0.6, reaction = "r2", enzyme = "r2"},
+  {exploc = 1, scale = 0.6, reaction = "r3", enzyme = "r3"},
+]
+
+km = [
+  {exploc = 1, scale = 0.6, metabolite = "M1", compartment = "e", enzyme = "r1"},
+  {exploc = 1, scale = 0.6, metabolite = "M1", compartment = "c", enzyme = "r1"},
+  {exploc = 1, scale = 0.6, metabolite = "M1", compartment = "c", enzyme = "r2"},
+  {exploc = 1, scale = 0.6, metabolite = "M2", compartment = "c", enzyme = "r3"},
+  {exploc = 1, scale = 0.6, metabolite = "M2", compartment = "e", enzyme = "r3"},
+]
+
+transfer_constant = [
+  {exploc = 1, scale = 0.6, enzyme = "r1"},
+  {exploc = 1, scale = 0.6, enzyme = "r2"},
+]
+
+dissociation_constant = [
+  {exploc = 1, scale = 0.6, enzyme = "r1", metabolite = "M2", compartment = "c", modification_type = "activation"},
+  {exploc = 1, scale = 0.6, enzyme = "r2", metabolite = "M1", compartment = "c", modification_type = "inhibition"},
+]
+
+dgf = [
+  {location = -1, metabolite = "M1", scale = 0.05},
+  {location = -2, metabolite = "M2", scale = 0.05},
+]
+
+psi = [
+  {location = -0.95, scale = 0.2, experiment = "condition1"},
+  {location = -0.95, scale = 0.2, experiment = "condition2"},
+]
+
+ki = [
+  {exploc = 1, scale = 0.6, enzyme = "r2", reaction = "r2", metabolite = "M1", compartment = "c"},
+]


### PR DESCRIPTION
This change adds an example maud output to Maud's data folder.

I added it to make it easier to test maudtools functions that require a maud output but there are probably some other uses too.

Checklist:

- [x] Updated any relevant documentation
- [x] Add an adr doc if appropriate
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [x] Integration tests passing
