### PR TITLE
Default factories

### DIFF
--- a/src/maud/data_model/maud_config.py
+++ b/src/maud/data_model/maud_config.py
@@ -1,7 +1,7 @@
 """Provides dataclass MaudConfig."""
 from typing import Optional
 
-from pydantic.dataclasses import dataclass
+from pydantic.dataclasses import dataclass, Field
 
 
 @dataclass
@@ -46,7 +46,7 @@ class MaudConfig:
     cpp_options: Optional[dict] = None
     variational_options: Optional[dict] = None
     user_inits_file: Optional[str] = None
-    ode_config: ODEConfig = ODEConfig()
+    ode_config: ODEConfig = Field(default_factory=ODEConfig)
     reject_non_steady: bool = True
     steady_state_threshold_abs: float = 1e-8
     steady_state_threshold_rel: float = 1e-3

--- a/src/maud/data_model/maud_config.py
+++ b/src/maud/data_model/maud_config.py
@@ -1,7 +1,7 @@
 """Provides dataclass MaudConfig."""
 from typing import Optional
 
-from pydantic.dataclasses import dataclass, Field
+from pydantic.dataclasses import Field, dataclass
 
 
 @dataclass

--- a/src/maud/data_model/maud_input.py
+++ b/src/maud/data_model/maud_input.py
@@ -23,8 +23,8 @@ class MaudInput:
     config: MaudConfig
     kinetic_model: KineticModel
     experiments: List[Experiment]
-    prior_input: PriorInput = PriorInput()
-    init_input: InitInput = InitInput()
+    prior_input: PriorInput = Field(default_factory=PriorInput)
+    init_input: InitInput = Field(default_factory=InitInput)
     parameters: ParameterSet = Field(init=False, exclude=True)
     stan_input_train: Dict = Field(init=False, exclude=True)
     stan_input_test: Dict = Field(init=False, exclude=True)


### PR DESCRIPTION
This change fixes a bug that I encountered on a fresh install of Maud. 

I think pydantic got a bit more pydantic about mutability in a recent release - this changes things to be correct.

Checklist:

- [x] Updated any relevant documentation
- [x] Add an adr doc if appropriate
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [x] Integration tests passing
