### PR TITLE
Feat: print more debug info on steady state failure

### DIFF
--- a/src/maud/stan/model.stan
+++ b/src/maud/stan/model.stan
@@ -251,17 +251,28 @@ transformed parameters {
         print("flux_train: ", flux_train[e]);
         print("conc_init: ", conc_init);
         print("conc_unbalanced_train: ", conc_unbalanced_train[e]);
+        print("log_conc_unbalanced_train_z: ", log_conc_unbalanced_train_z[e]);
         print("conc_enzyme_experiment: ", conc_enzyme_experiment);
+        print("log_conc_enzyme_train_z: ", log_conc_enzyme_train_z[e]);
         print("km: ", km);
+        print("log_km_z: ", log_km_z);
         print("drain_train: ", drain_train[e]);
+        print("drain_train_z: ", drain_train_z[e]);
         print("kcat: ", kcat);
+        print("log_kcat_z: ", log_kcat_z);
         print("dgr_train: ", dgr_train[e]);
         print("ki: ", ki);
+        print("log_ki_z: ", log_ki_z);
         print("dissociation_constant: ", dissociation_constant);
+        print("log_dissociation_constant_z: ", log_dissociation_constant_z);
         print("transfer_constant: ", transfer_constant);
+        print("log_transfer_constant_z: ", log_transfer_constant_z);
         print("kcat_pme: ", kcat_pme);
+        print("log_kcat_pme_z: ", log_kcat_pme_z);
         print("conc_pme_experiment: ", conc_pme_experiment);
+        print("log_conc_pme_train_z: ", log_conc_pme_train_z[e]);
         print("psi_train: ", psi_train);
+        print("psi_train_z: ", psi_train_z);
         reject("Rejecting");
       }
     }


### PR DESCRIPTION
This change adds information about the values of parameters relative to their prior distributions to the message that Maud prints when there is a steady state failure. This is useful when trying to diagnose whether a failure could be fixed by different priors.


Checklist:

- [x] Updated any relevant documentation
- [x] Add an adr doc if appropriate
- [x] Include links to any relevant issues in the description
- [ ] Unit tests passing
- [x] Integration tests passing
