### PR TITLE
Units

### DIFF
--- a/docs/usage/inputting.rst
+++ b/docs/usage/inputting.rst
@@ -40,15 +40,20 @@ The following optional fields can also be specified:
 
 - :code:`reject_non_steady` Boolean saying whether to reject draws that enter non-steady states
 - :code:`ode_config` Table of configuration options for Stan's ode solver
-- :code:`cmdstanpy_config` Table of keyword arguments to the cmdstanpy method `sample <https://cmdstanpy.readthedocs.io/en/v1.0.1/api.html#cmdstanpy.CmdStanModel.sample>`_
+- :code:`cmdstanpy_config` Table of keyword arguments to the cmdstanpy method `CmdStanModel.sample <https://cmdstanpy.readthedocs.io/en/v1.1.0/api.html#cmdstanpy.CmdStanModel.sample>`_
 - :code:`cmdstanpy_config_predict` Table of overriding sample keyword argments for predictions
-- :code:`stanc_options` Table of valid choices for `CmdStanModel <https://cmdstanpy.readthedocs.io/en/v1.0.1/api.html#cmdstanpy.CmdStanModel>`_ argument `stanc_options`
-- :code:`cpp_options` Table of valid choices for  `CmdStanModel <https://cmdstanpy.readthedocs.io/en/v1.0.1/api.html#cmdstanpy.CmdStanModel>`_ argument `cpp_options`
-- :code:`variational_options` Arguments for CmdStanModel.variational
+- :code:`stanc_options` Table of valid choices for `CmdStanModel <https://cmdstanpy.readthedocs.io/en/v1.1.0/api.html#cmdstanpy.CmdStanModel>`_ argument `stanc_options`
+- :code:`cpp_options` Table of valid choices for  `CmdStanModel <https://cmdstanpy.readthedocs.io/en/v1.1.0/api.html#cmdstanpy.CmdStanModel>`_ argument `cpp_options`
+- :code:`variational_options` Arguments for the cmdstanpy method :code:`CmdStanModel.variational <https://cmdstanpy.readthedocs.io/en/v1.1.0/api.html#cmdstanpy.CmdStanModel.variational>`_
 - :code:`user_inits_file` path to a toml file of initial values
 - :code:`steady_state_threshold_abs` absolute threshold for Sv=0 be at steady state
 - :code:`steady_state_threshold_rel` relative threshold for Sv=0 be at steady state
+- :code:`default_initial_concentration` default initial concentration for unmeasured species
 - :code:`drain_small_conc_corrector` number for correcting small conc drains
+- :code:`molecule_unit` A unit for counting molecules, like 'mol' or 'mmol'
+- :code:`volume_unit` A unit for measuring volume, like 'L'
+- :code:`energy_unit` A unit for measuring energy, like 'J' or 'kJ'
+
 
 Here is an example configuration file:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ url = https://github.com/biosustain/Maud
 download_url = https://pypi.org/project/maud-metabolic-models/
 author = Novo Nordisk Foundation Center for Biosustainability, Technical University of Denmark
 author_email = tedgro@dtu.dk
-version = 0.4.0.2
+version = 0.4.0.3
 # Please consult https://pypi.org/classifiers/ for a full list.
 classifiers =
     Development Status :: 2 - Pre-Alpha

--- a/src/maud/data/example_inputs/methionine/inits.toml
+++ b/src/maud/data/example_inputs/methionine/inits.toml
@@ -2,7 +2,7 @@ km = [
   {metabolite = "adn", compartment = "c", enzyme = "AHC1", reaction = "AHC", init = 5.66E-06},
   {metabolite = "ahcys", compartment = "c", enzyme = "AHC1", reaction = "AHC", init = 2.32E-05},
   {metabolite = "hcys-L", compartment = "c", enzyme = "AHC1", reaction = "AHC", init = 1.06E-05},
-  {metabolite = "glyb", compartment = "c", ennnnnzyme = "BHMT1", reaction = "BHMT", init = 0.00845898},
+  {metabolite = "glyb", compartment = "c", enzyme = "BHMT1", reaction = "BHMT", init = 0.00845898},
   {metabolite = "hcys-L", compartment = "c", enzyme = "BHMT1", reaction = "BHMT", init = 1.98E-05},
   {metabolite = "hcys-L", compartment = "c", enzyme = "CBS1", reaction = "CBS", init = 4.24E-05},
   {metabolite = "ser-L", compartment = "c", enzyme = "CBS1", reaction = "CBS", init = 2.83E-06},
@@ -42,13 +42,13 @@ ki = [
 ]
 
 dissociation_constant = [
-  {metabolite = "mlthf", compartment = "c", enzyme = "GNMT1", reaction = "GNMT", init = 0.000228576},
-  {metabolite = "amet", compartment = "c", enzyme = "MTHFR1", reaction = "MTHFR", init = 1.46E-05},
-  {metabolite = "amet", compartment = "c", enzyme = "CBS1", reaction = "CBS", init = 9.30E-05},
-  {metabolite = "amet", compartment = "c", enzyme = "GNMT1", reaction = "GNMT", init = 1.98E-05},
-  {metabolite = "amet", compartment = "c", enzyme = "MAT3", reaction = "METAT", init = 0.000316641},
-  {metabolite = "met-L", compartment = "c", enzyme = "MAT3", reaction = "METAT", init = 0.00059999},
-  {metabolite = "ahcys", compartment = "c", enzyme = "MTHFR1", reaction = "MTHFR", init = 2.45E-06},
+  {metabolite = "mlthf", compartment = "c", enzyme = "GNMT1", init = 0.000228576, modification_type = "inhibition"},
+  {metabolite = "amet", compartment = "c", enzyme = "MTHFR1", init = 1.46E-05, modification_type = "inhibition"},
+  {metabolite = "amet", compartment = "c", enzyme = "CBS1", init = 9.30E-05, modification_type = "activation"},
+  {metabolite = "amet", compartment = "c", enzyme = "GNMT1", init = 1.98E-05, modification_type = "activation"},
+  {metabolite = "amet", compartment = "c", enzyme = "MAT3", init = 0.000316641, modification_type = "activation"},
+  {metabolite = "met-L", compartment = "c", enzyme = "MAT3", init = 0.00059999, modification_type = "activation"},
+  {metabolite = "ahcys", compartment = "c", enzyme = "MTHFR1", init = 2.45E-06, modification_type = "activation"},
 ]
 
 transfer_constant = [

--- a/src/maud/data/example_inputs/methionine/priors.toml
+++ b/src/maud/data/example_inputs/methionine/priors.toml
@@ -42,13 +42,13 @@ ki = [
 ]
 
 dissociation_constant = [
-  {metabolite = "amet" ,compartment = "c", enzyme = "MAT3", reaction = "METAT", exploc = 0.0001,scale = 0.001, modification_type = "inhibition"},
-  {metabolite = "met-L", compartment = "c", enzyme = "MAT3", reaction = "METAT", exploc = 0.00045,scale = 0.0008, modification_type = "inhibition"},# Based on met_c conc
-  {metabolite = "amet", compartment = "c", enzyme = "GNMT1", reaction = "GNMT", exploc = 0.00003,scale = 0.002, modification_type = "inhibition"},
-  {metabolite = "mlthf", compartment = "c", enzyme = "GNMT1", reaction = "GNMT", exploc = 0.0003,scale = 2, modification_type = "activation"},
-  {metabolite = "amet", compartment = "c", enzyme = "CBS1", reaction = "CBS", exploc = 9.22e-05,scale = 2, modification_type = "inhibition"},
-  {metabolite = "ahcys", compartment = "c", enzyme = "MTHFR1", reaction = "MTHFR", exploc = 0.000003,scale = 2, modification_type = "inhibition"},
-  {metabolite = "amet", compartment = "c", enzyme = "MTHFR1", reaction = "MTHFR", exploc = 0.000003,scale = 2, modification_type = "activation"},
+  {metabolite = "amet" ,compartment = "c", enzyme = "MAT3", reaction = "METAT", exploc = 0.0001,scale = 0.001, modification_type = "activation"},
+  {metabolite = "met-L", compartment = "c", enzyme = "MAT3", reaction = "METAT", exploc = 0.00045,scale = 0.0008, modification_type = "activation"},# Based on met_c conc
+  {metabolite = "amet", compartment = "c", enzyme = "GNMT1", reaction = "GNMT", exploc = 0.00003,scale = 0.002, modification_type = "activation"},
+  {metabolite = "mlthf", compartment = "c", enzyme = "GNMT1", reaction = "GNMT", exploc = 0.0003,scale = 2, modification_type = "inhibition"},
+  {metabolite = "amet", compartment = "c", enzyme = "CBS1", reaction = "CBS", exploc = 9.22e-05,scale = 2, modification_type = "activation"},
+  {metabolite = "ahcys", compartment = "c", enzyme = "MTHFR1", reaction = "MTHFR", exploc = 0.000003,scale = 2, modification_type = "activation"},
+  {metabolite = "amet", compartment = "c", enzyme = "MTHFR1", reaction = "MTHFR", exploc = 0.000003,scale = 2, modification_type = "inhibition"},
 ]
 
 transfer_constant = [

--- a/src/maud/data_model/maud_config.py
+++ b/src/maud/data_model/maud_config.py
@@ -4,7 +4,7 @@ from typing import Optional
 from pydantic.dataclasses import Field, dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class ODEConfig:
     """Config that is specific to the ODE solver."""
 

--- a/src/maud/data_model/maud_config.py
+++ b/src/maud/data_model/maud_config.py
@@ -32,7 +32,11 @@ class MaudConfig:
     :param user_inits_file: path to a csv file of initial values.
     :param steady_state_threshold_abs: absolute threshold for Sv=0 be at steady state
     :param steady_state_threshold_rel: relative threshold for Sv=0 be at steady state
-    :param: drain_small_conc_corrector: number for correcting small conc drains
+    :param default_initial_concentration: in molecule_unit per volume_unit
+    :param drain_small_conc_corrector: number for correcting small conc drains
+    :param molecule_unit: A unit for counting molecules, like 'mol' or 'mmol'
+    :param volume_unit: A unit for measuring volume, like 'L'
+    :param energy_unit: A unit for measuring energy, like 'J' or 'kJ'
     """
 
     name: str
@@ -52,3 +56,6 @@ class MaudConfig:
     steady_state_threshold_rel: float = 1e-3
     default_initial_concentration: float = 0.01
     drain_small_conc_corrector: float = 1e-6
+    molecule_unit: str = "mmol"
+    volume_unit: str = "L"
+    energy_unit: str = "kJ"


### PR DESCRIPTION
This change adds units to the `MaudConfig` object.

This has no effect in Maud, which doesn't care about units at the moment (this may have to change when we implement molar balance #231), but can be helpful when using maudtools to fetch dgf priors from equilibrator.

Checklist:

- [x] Updated any relevant documentation
- [x] Add an adr doc if appropriate NA
- [x] Include links to any relevant issues in the description
- [x] Unit tests passing
- [x] Integration tests passing
