### PR TITLE
feat: optimize model

### DIFF
--- a/docs/usage/post_installation_usage.rst
+++ b/docs/usage/post_installation_usage.rst
@@ -7,6 +7,7 @@ Maud provides the following commands:
 - :code:`maud sample [PATH TO MAUD INPUT]`
 - :code:`maud simulate [PATH TO MAUD INPUT]`
 - :code:`maud variational [PATH TO MAUD INPUT]`
+- :code:`maud optimize [PATH TO MAUD INPUT]`
 - :code:`maud predict [PATH TO MAUD SAMPLE OUTPUT]`
 
 The documentation for each of these commands is as follows:
@@ -22,6 +23,10 @@ The documentation for each of these commands is as follows:
 .. click:: maud.cli:variational_command
    :show-nested:
    :prog: variational
+
+.. click:: maud.cli:optimize_command
+   :show-nested:
+   :prog: optimize
 
 .. click:: maud.cli:predict_command
    :show-nested:

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -159,7 +159,7 @@ def simulate_command(data_path, output_dir, n):
     default=EXAMPLE_INPUT_PATH,
 )
 def optimize_command(data_path, output_dir):
-    """Optimize a Maximum A Posteriori from the model parameters."""
+    """Optimize the model parameters."""
     click.echo(do_optimize(data_path, output_dir))
 
 
@@ -269,7 +269,7 @@ def do_simulate(data_path, output_dir, n):
 
 
 def do_optimize(data_path, output_dir):
-    """Generate a Maximum A Posteriori from the model parameters."""
+    """Optimize the model parameters."""
 
     mi = load_maud_input(data_path=data_path)
     now = datetime.now().strftime("%Y%m%d%H%M%S")

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -27,7 +27,7 @@ import importlib_resources
 from maud.data.example_inputs import linear
 from maud.getting_idatas import get_idata
 from maud.loading_maud_inputs import load_maud_input
-from maud.running_stan import predict, sample, simulate, variational
+from maud.running_stan import optimize, predict, sample, simulate, variational
 
 
 EXAMPLE_INPUT_PATH = importlib_resources.files(linear)._paths[0]
@@ -151,6 +151,18 @@ def simulate_command(data_path, output_dir, n):
     click.echo(do_simulate(data_path, output_dir, n))
 
 
+@cli.command("optimize")
+@click.option("--output_dir", default=".", help="Where to save the output")
+@click.argument(
+    "data_path",
+    type=click.Path(exists=True, dir_okay=True, file_okay=False),
+    default=EXAMPLE_INPUT_PATH,
+)
+def optimize_command(data_path, output_dir):
+    """Generate draws from the initial values."""
+    click.echo(do_optimize(data_path, output_dir))
+
+
 def do_simulate(data_path, output_dir, n):
     """Generate draws from the initial values."""
 
@@ -184,6 +196,113 @@ def do_simulate(data_path, output_dir, n):
         .unstack()
         .T
     )
+    print("\n\nSimulated enzyme concentrations:")
+    print(
+        idata.posterior["conc_enzyme_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated reaction delta Gs:")
+    print(idata.posterior["dgr_train"].mean(dim=["chain", "draw"]).to_series())
+    print("\n\nSimulated measurements:")
+    print(
+        idata.posterior_predictive["yrep_conc_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+    )
+    print(
+        idata.posterior_predictive["yrep_flux_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+    )
+    print("\n\nSimulated log likelihoods:")
+    print(
+        idata.log_likelihood["llik_conc_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+    )
+    print(
+        idata.log_likelihood["llik_flux_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+    )
+    print("\n\nSimulated allostery terms:")
+    print(
+        idata.posterior["allostery_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated reversibility terms:")
+    print(
+        idata.posterior["reversibility_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated saturation terms:")
+    print(
+        idata.posterior["saturation_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    if mi.kinetic_model.phosphorylations is not None:
+        print("\n\nSimulated phosphorylation terms:")
+        print(
+            idata.posterior["phosphorylation_train"]
+            .mean(dim=["chain", "draw"])
+            .to_series()
+            .unstack()
+            .T
+        )
+    print("\n\nSimulated membrane potential:")
+    print(
+        idata.posterior["psi_train"].mean(dim=["chain", "draw"]).to_series().T
+    )
+    return output_path
+
+
+def do_optimize(data_path, output_dir):
+    """Generate a Maximum Likelihood Estimate from the model parameters."""
+
+    mi = load_maud_input(data_path=data_path)
+    now = datetime.now().strftime("%Y%m%d%H%M%S")
+    output_name = f"maud_output_opt-{mi.config.name}-{now}"
+    output_path = os.path.join(output_dir, output_name)
+    samples_path = os.path.join(output_path, "samples")
+    ui_dir = os.path.join(output_path, "user_input")
+    print("Creating output directory: " + output_path)
+    os.mkdir(output_path)
+    os.mkdir(samples_path)
+    print(f"Copying user input from {data_path} to {ui_dir}")
+    shutil.copytree(data_path, ui_dir)
+    stanfit = optimize(mi, samples_path)
+    idata = get_idata(stanfit.runset.csv_files, mi, "train")
+    idata.to_json(os.path.join(output_path, "idata.json"))
+    print("\n\nSimulated concentrations:")
+    print(
+        idata.posterior["conc_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated fluxes:")
+    print(
+        idata.posterior["flux_train"]
+        .mean(dim=["chain", "draw"])
+        .to_series()
+        .unstack()
+        .T
+    )
+    print("\n\nSimulated kms:")
+    print(idata.posterior["km"].mean(dim=["chain", "draw"]).to_series())
     print("\n\nSimulated enzyme concentrations:")
     print(
         idata.posterior["conc_enzyme_train"]

--- a/src/maud/cli.py
+++ b/src/maud/cli.py
@@ -159,7 +159,7 @@ def simulate_command(data_path, output_dir, n):
     default=EXAMPLE_INPUT_PATH,
 )
 def optimize_command(data_path, output_dir):
-    """Generate draws from the initial values."""
+    """Optimize a Maximum A Posteriori from the model parameters."""
     click.echo(do_optimize(data_path, output_dir))
 
 
@@ -269,7 +269,7 @@ def do_simulate(data_path, output_dir, n):
 
 
 def do_optimize(data_path, output_dir):
-    """Generate a Maximum Likelihood Estimate from the model parameters."""
+    """Generate a Maximum A Posteriori from the model parameters."""
 
     mi = load_maud_input(data_path=data_path)
     now = datetime.now().strftime("%Y%m%d%H%M%S")

--- a/src/maud/data_model/maud_config.py
+++ b/src/maud/data_model/maud_config.py
@@ -29,6 +29,7 @@ class MaudConfig:
     :param stanc_options: Valid choices for CmdStanModel argument `stanc_options`.
     :param cpp_options: Valid choices for CmdStanModel `cpp_options`.
     :param variational_options: Arguments for CmdStanModel.variational.
+    :param optimize_options: Arguments for CmdStanModel.optimize.
     :param user_inits_file: path to a csv file of initial values.
     :param steady_state_threshold_abs: absolute threshold for Sv=0 be at steady state
     :param steady_state_threshold_rel: relative threshold for Sv=0 be at steady state
@@ -49,6 +50,7 @@ class MaudConfig:
     stanc_options: Optional[dict] = None
     cpp_options: Optional[dict] = None
     variational_options: Optional[dict] = None
+    optimize_options: Optional[dict] = None
     user_inits_file: Optional[str] = None
     ode_config: ODEConfig = Field(default_factory=ODEConfig)
     reject_non_steady: bool = True

--- a/src/maud/running_stan.py
+++ b/src/maud/running_stan.py
@@ -43,6 +43,17 @@ SIM_CONFIG = {
     "show_progress": False,
     "threads_per_chain": 1,
 }
+DEFAULT_OPTIMIZE_CONFIG = {
+    "algorithm": "LBFGS",
+    "iter": 3000,
+    "init_alpha": 1e-4,
+    "tol_param": 1e-12,
+    "history_size": 10,
+    "show_console": True,
+    "refresh": 1,
+    "save_profile": True,
+    "save_iterations": True,
+}
 
 
 def sample(mi: MaudInput, output_dir: str) -> CmdStanMCMC:
@@ -123,6 +134,9 @@ def optimize(mi: MaudInput, output_dir: str) -> CmdStanMLE:
     :param mi: a MaudInput object
     :param output_dir: a string specifying where to save the output.
     """
+    mi_options = (
+        {} if mi.config.optimize_options is None else mi.config.optimize_options
+    )
     model = cmdstanpy.CmdStanModel(
         stan_file=os.path.join(HERE, STAN_PROGRAM_RELATIVE_PATH),
         cpp_options=mi.config.cpp_options,
@@ -130,19 +144,13 @@ def optimize(mi: MaudInput, output_dir: str) -> CmdStanMLE:
     )
     set_up_output_dir(output_dir, mi)
     return model.optimize(
-        output_dir=output_dir,
-        # upper bound, will stop once the gradients become small enough
-        iter=3000,
         data=os.path.join(output_dir, "input_data_train.json"),
         inits=os.path.join(output_dir, "inits.json"),
-        algorithm="LBFGS",
-        init_alpha=1e-4,
-        tol_param=1e-12,
-        history_size=10,
-        show_console=True,
-        refresh=1,
-        save_profile=True,
-        save_iterations=True,
+        output_dir=output_dir,
+        **{
+            **DEFAULT_OPTIMIZE_CONFIG,
+            **mi_options,
+        },
     )
 
 


### PR DESCRIPTION
From the Maud debugging sessions, optimizing the model to get a Maximum A Posteriori (MAP) has revealed as a great way to debug which prior are making the model dysfunctional.

I gathered the [optimize snippet](https://github.com/biosustain/maud-debugging/tree/main/debugging-tools) from @NicholasCowie into a new cli argument `maud optimize [DATA]`.

Nomenclature question: In the docs, I have written "Maximum Likelihood Estimate" but would MAP be more appropriate in the Bayesian sense? Or is it the same? In the `cmdstanpy` docs for `model.optimize()`, they use MLE.

Checklist:

- [x] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [x] Unit tests passing
- [x] Integration tests passing
