### PR TITLE
Fix indexing on `get_allostery`

### DIFF
--- a/maud/stan/functions.stan
+++ b/maud/stan/functions.stan
@@ -216,7 +216,8 @@ functions {
                        // one per allostery
                        array[] int allostery_mic,
                        // one per allostery
-                       array[] int edge_to_tc // one per edge
+                       array[] int edge_to_tc, // one per edge
+                       array[] int edge_to_enzyme
                        ) {
     int N_edge = size(allostery_ix_bounds);
     vector[N_edge] out = rep_vector(1, N_edge);
@@ -241,7 +242,7 @@ functions {
       }
       out[f] = inv(1
                    + tc_edge
-                     * (free_enzyme_ratio[f] * Q_num / Q_denom) ^ subunits[f]);
+                     * (free_enzyme_ratio[edge_to_enzyme[f]] * Q_num / Q_denom) ^ subunits[edge_to_enzyme[f]]);
     }
     return out;
   }
@@ -358,7 +359,7 @@ functions {
                                              subunits, allostery_ix_long,
                                              allostery_ix_bounds,
                                              allostery_type, allostery_mic,
-                                             edge_to_tc);
+                                             edge_to_tc, edge_to_enzyme);
     vector[N_edge] phosphorylation = get_phosphorylation(kcat_pme, conc_pme,
                                                          phos_ix_long,
                                                          phos_ix_bounds,
@@ -496,7 +497,7 @@ functions {
                                              subunits, allostery_ix_long,
                                              allostery_ix_bounds,
                                              allostery_type, allostery_mic,
-                                             edge_to_tc);
+                                             edge_to_tc, edge_to_enzyme);
     vector[N_edge] phosphorylation = get_phosphorylation(kcat_pme, conc_pme,
                                                          phos_ix_long,
                                                          phos_ix_bounds,
@@ -616,7 +617,7 @@ functions {
                                                              allostery_ix_bounds,
                                                              allostery_type,
                                                              allostery_mic,
-                                                             edge_to_tc);
+                                                             edge_to_tc, edge_to_enzyme);
     complex_vector[N_edge] phosphorylation = get_phosphorylation(kcat_pme,
                                                                  conc_pme,
                                                                  phos_ix_long,
@@ -652,7 +653,8 @@ functions {
                                        // one per allostery
                                        array[] int allostery_mic,
                                        // one per allostery
-                                       array[] int edge_to_tc // one per edge
+                                       array[] int edge_to_tc, // one per edge
+                                       array[] int edge_to_enzyme
                                        ) {
     int N_edge = size(allostery_ix_bounds);
     complex_vector[N_edge] out = rep_vector(1, N_edge);
@@ -678,7 +680,7 @@ functions {
       out[f] = 1
                / (1
                   + tc_edge
-                    * (free_enzyme_ratio[f] * Q_num / Q_denom) ^ subunits[f]);
+                    * (free_enzyme_ratio[edge_to_enzyme[f]] * Q_num / Q_denom) ^ subunits[edge_to_enzyme[f]]);
     }
     return out;
   }

--- a/maud/stan/model.stan
+++ b/maud/stan/model.stan
@@ -375,7 +375,7 @@ generated quantities {
                                        dissociation_constant, subunits,
                                        allostery_ix_long,
                                        allostery_ix_bounds, allostery_type,
-                                       allostery_mic, edge_to_tc);
+                                       allostery_mic, edge_to_tc, edge_to_enzyme);
     phosphorylation_train[e] = get_phosphorylation(kcat_pme,
                                                    conc_pme_train[e],
                                                    phosphorylation_ix_long,

--- a/maud/stan/out_of_sample_model.stan
+++ b/maud/stan/out_of_sample_model.stan
@@ -238,7 +238,7 @@ generated quantities {
                                       dissociation_constant, subunits,
                                       allostery_ix_long, allostery_ix_bounds,
                                       allostery_type, allostery_mic,
-                                      edge_to_tc);
+                                      edge_to_tc, edge_to_enzyme);
     phosphorylation_test[e] = get_phosphorylation(kcat_pme, conc_pme_test[e],
                                                   phosphorylation_ix_long,
                                                   phosphorylation_ix_bounds,


### PR DESCRIPTION
`get_allostery` was wrong in the indexing of free enzyme ration, same as vmax was before.

Would be good to have an example with `N_edge` > `N_enzyme` (with drains) to test for this cases.

Checklist:

- [ ] Updated any relevant documentation
- [ ] Add an adr doc if appropriate
- [ ] Include links to any relevant issues in the description
- [x] Unit tests passing
- [ ] Integration tests passing
