### PR TITLE
Allostery free enzyme ratio bug

### DIFF
--- a/maud/stan/functions.stan
+++ b/maud/stan/functions.stan
@@ -242,7 +242,7 @@ functions {
       }
       out[f] = inv(1
                    + tc_edge
-                     * (free_enzyme_ratio[edge_to_enzyme[f]] * Q_num / Q_denom) ^ subunits[edge_to_enzyme[f]]);
+                     * (free_enzyme_ratio[f] * Q_num / Q_denom) ^ subunits[edge_to_enzyme[f]]);
     }
     return out;
   }
@@ -680,7 +680,7 @@ functions {
       out[f] = 1
                / (1
                   + tc_edge
-                    * (free_enzyme_ratio[edge_to_enzyme[f]] * Q_num / Q_denom) ^ subunits[edge_to_enzyme[f]]);
+                    * (free_enzyme_ratio[f] * Q_num / Q_denom) ^ subunits[edge_to_enzyme[f]]);
     }
     return out;
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,5 +184,5 @@ legacy_tox_ini = """
         safety
     commands=
         pip install --upgrade pip
-        safety check -i 44715 -i 51549
+        safety check -i 44715 -i 51549 -i 70612
 """


### PR DESCRIPTION
Fixes a pretty big bug in Maud's Stan code: allostery was incorrect for models with isoenzymes because the function `get_allostery` was using the wrong free enzyme ratios.

Checklist:

- [ ] Updated any relevant documentation NA
- [ ] Add an adr doc if appropriate NA
- [ ] Include links to any relevant issues in the description NA
- [x] Unit tests passing
- [x] Integration tests passing
